### PR TITLE
fix(sniffer): DAY 76 — resolve SIGSEGV ByteSizeLong + proto3 sentinel…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ Democratize enterprise-grade cybersecurity for hospitals, schools, and small org
 ## 🏗️ Architecture
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
+┌────────────────────────────────────────────────────────────────-─┐
 │                         ML Defender Pipeline                     │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                   │
+├─────────────────────────────────────────────────────────────────-┤
+│                                                                  │
 │  Network Traffic (eBPF/XDP)                                      │
-│         ↓                                                         │
+│         ↓                                                        │
 │  ┌──────────────────┐                                            │
-│  │  sniffer (C++20) │  eBPF/XDP packet capture                  │
+│  │  sniffer (C++20) │  eBPF/XDP packet capture                   │
 │  │                  │  - ShardedFlowManager (16 shards)          │
 │  │                  │  - Fast Detector (heuristics)              │
 │  │                  │  - 4x embedded ML feature extraction       │
@@ -36,22 +36,23 @@ Democratize enterprise-grade cybersecurity for hospitals, schools, and small org
 │         ↓  ZeroMQ (encrypted)                                    │
 │  ┌──────────────────┐                                            │
 │  │  ml-detector     │  4x Embedded RandomForest Models           │
-│  │  (C++20)         │  - DDoS Detection (97.6% accuracy)        │
+│  │  (C++20)         │  - DDoS Detection (97.6% accuracy)         │
 │  │                  │  - Ransomware Detection                    │
 │  │                  │  - Traffic Classification                  │
 │  │                  │  - Internal Anomaly Detection              │
 │  └──────────────────┘                                            │
-│         ↓                                                         │
-│  ┌──────────────────┐  ChaCha20-Poly1305 + LZ4                  │
+│         ↓                                                        │
+│  ┌──────────────────┐  ChaCha20-Poly1305 + LZ4                   │ 
 │  │  Crypto Pipeline │  36K events, 0 errors ✅                   │
-│  └──────────────────┘                                            │
-│         ↓                                                         │
+│  |     (C++20)      |                                            |
+|  └──────────────────┘                                            │
+│         ↓                                                        │
 │  ┌──────────────────┐                                            │
-│  │  etcd-server     │  Distributed Config + Key Management      │
-│  │  (C++)           │  Automatic crypto seed exchange            │
+│  │  etcd-server     │  Distributed Config + Key Management       │ 
+│  │  (C++20)         │  Automatic crypto seed exchange            │
 │  │                  │  HMAC secrets management ✅                │
 │  └──────────────────┘                                            │
-│         ↓                                                         │
+│         ↓                                                        │
 │  ┌──────────────────┐                                            │
 │  │ firewall-acl     │  Autonomous Blocking (Day 52 ✅)           │
 │  │ agent (C++20)    │  - IPSet/IPTables integration              │
@@ -59,20 +60,20 @@ Democratize enterprise-grade cybersecurity for hospitals, schools, and small org
 │  │                  │  - Config-driven (JSON is law)             │
 │  │                  │  - 364 events/sec tested                   │
 │  └──────────────────┘                                            │
-│         ↓                                                         │
+│         ↓                                                        │
 │  ┌──────────────────┐                                            │
 │  │  rag-ingester    │  Log Parsing + Vector Ingestion            │
-│  │  (Python)        │  - ml-detector logs ✅                     │
-│  │                  │  - firewall logs (planned)                 │
+│  │  (C++20)         │  - ml-detector logs ✅                     │
+│  │                  │  - firewall logs    ✅                     │
 │  └──────────────────┘                                            │
-│         ↓                                                         │
+│         ↓                                                        │
 │  ┌──────────────────┐                                            │
 │  │  rag (TinyLlama) │  Natural Language Intelligence             │
 │  │  + FAISS         │  - Forensic queries                        │
-│  │                  │  - ML retraining data                      │
+│  │  (C++20)         │  - ML retraining data                      │
 │  └──────────────────┘                                            │
-│                                                                   │
-└─────────────────────────────────────────────────────────────────┘
+│                                                                  │
+└─────────────────────────────────────────────────────────────────-┘
 ```
 
 ---
@@ -120,7 +121,8 @@ Democratize enterprise-grade cybersecurity for hospitals, schools, and small org
 - [x] ChaCha20-Poly1305 encryption
 - [x] LZ4 compression
 - [x] Dual-NIC deployment (host IDS + gateway mode)
-- [x] Validated with real malware (CTU-13 Neris botnet, 97.6% accuracy)
+- [x] Validated with real malware (CTU-13 Neris botnet, 97.6% accuracy) 
+- [] Validated with real malware (CTU-13 Neris botnet, with full open source components)
 - [x] Dual-Score architecture (fast + ML scores)
 - [x] RAG Logger with HMAC artifact integrity
 
@@ -223,7 +225,7 @@ across 4 submessages with `0.5f` Phase 1 sentinel values before serialization.
 etcd-server:   ✅ RUNNING
 rag-security:  ✅ RUNNING
 rag-ingester:  ✅ RUNNING
-ml-detector:   ✅ RUNNING  ← Previously crashing on every event
+ml-detector:   ✅ RUNNING  
 sniffer:       ✅ RUNNING
 firewall:      ✅ RUNNING
 ```


### PR DESCRIPTION
… init

Root cause: Proto3 C++ 3.21 does not serialize submessages where all float fields equal 0.0f (default). Receiver gets null pointer → SIGSEGV in ByteSizeLong() when ml-detector processes embedded detector submessages.

Three separate routes in ring_consumer.cpp were affected:
- populate_protobuf_event() — line 872
- send_fast_alert()         — line 1170
- send_ransomware_features() — line 1255 (DAY 75 fix was incomplete)

Fix: init_embedded_sentinels() helper initializes all 40 fields across 4 submessages (DDoSFeatures, RansomwareEmbeddedFeatures, TrafficFeatures, InternalFeatures) with 0.5f Phase 1 sentinel values before serialization.

Additional fixes in this session:
- snappy::Uncompress() wrong signature (2 args → 3): .data(), .size()
- libsnappy.pc symlink for cmake discovery

Pipeline validated: 6/6 components RUNNING, ml-detector VIVO after 60s+
Regression tests: all green (no regressions)

Phase 2 pending: replace 0.5f sentinels with real extracted values from ShardedFlowManager in populate_ml_defender_features() to enable F1-score validation against CTU-13 dataset.

Co-authored-by: Claude (Anthropic) GROK4 Gemini, Qwen, DeepSeek, ChatGPT, Alonso Isidoro Román

this bug was epic to fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README.md with minor formatting improvements including diagram adjustments, text alignment refinements, and status message updates for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->