### PR TITLE
docs: add living contract documentation (DAY 92)

### DIFF
--- a/docs/contracts/JSON contracts
+++ b/docs/contracts/JSON contracts
@@ -1,0 +1,475 @@
+# JSON Contracts — Configuración de Componentes
+
+> **Principio:** `JSON is the law` — toda configuración operacional vive en JSON, nunca en código hardcodeado.
+> **Última revisión:** DAY 92 — 20 marzo 2026
+
+---
+
+## Índice
+
+1. [sniffer.json](#snifferjson)
+2. [ml_detector_config.json](#ml_detector_configjson)
+3. [firewall.json](#firewalljson)
+4. [rag-ingester.json](#rag-ingesterjson)
+5. [rag-config.json](#rag-configjson)
+6. [Convenciones comunes](#convenciones-comunes)
+7. [Flujo de datos entre componentes](#flujo-de-datos-entre-componentes)
+
+---
+
+## sniffer.json
+
+**Path:** `sniffer/config/sniffer.json`
+**Versión actual:** `3.3.3`
+**Componente:** `cpp_evolutionary_sniffer`
+
+### Deployment — modos de operación
+
+El sniffer soporta 4 modos de despliegue:
+
+| Modo | Descripción |
+|---|---|
+| `host-only` | NIC única — protege solo el host (defensa bastión) |
+| `gateway-only` | NIC única — inspecciona tráfico en tránsito (modo router) |
+| `dual` | Dual NIC — protección de host + inspección gateway simultánea |
+| `validation` | Testing — soporte de replay libpcap para validación con PCAPs |
+
+**Configuración activa:** `dual`
+
+**Interfaces Vagrant (entorno lab):**
+
+| Interfaz | Rol | IP | Comportamiento |
+|---|---|---|---|
+| `eth0` | NAT | — | Administración Vagrant |
+| `eth1` | WAN / host-based | `192.168.56.20` | Captura ingress only — `interface_mode=1` |
+| `eth2` | LAN / gateway | `192.168.100.1` | Captura bidireccional — `interface_mode=2` |
+
+### Profiles
+
+| Profile | Worker threads | Compresión | Uso |
+|---|---|---|---|
+| `lab` | 2 | nivel 1 | Entorno Vagrant/VirtualBox |
+| `cloud` | 8 | nivel 3 | Instancias cloud |
+| `bare_metal` | 16 | nivel 1 | Hardware dedicado |
+| `dual_nic` | 6 | nivel 1 | Dual-NIC lab (activo) |
+
+**Profile activo:** `dual_nic`
+
+### Captura (sección `capture`)
+
+| Parámetro | Valor | Descripción |
+|---|---|---|
+| `mode` | `ebpf_skb` | Modo eBPF SKB (compatible VirtualBox) |
+| `xdp_mode` | `skb` | XDP genérico |
+| `excluded_ports` | `[22]` | SSH excluido siempre |
+| `default_action` | `capture` | Capturar todo lo no excluido |
+| `included_protocols` | `tcp, udp, icmp` | Protocolos capturados |
+| `buffer_size` | 65536 | Tamaño del buffer de captura |
+
+### Kernel space — features extraídas en eBPF
+
+```
+source_ip, destination_ip, source_port, destination_port,
+protocol_number, total_forward_packets, total_backward_packets,
+total_forward_bytes, total_backward_bytes,
+fin_flag_count, syn_flag_count, rst_flag_count,
+psh_flag_count, ack_flag_count, urg_flag_count
+```
+
+### Transporte
+
+| Parámetro | Valor |
+|---|---|
+| `compression.algorithm` | `lz4` (nivel 1) |
+| `encryption.algorithm` | `chacha20-poly1305` |
+| `encryption.key_rotation_hours` | 24 |
+| `zmq_curve_enabled` | `true` |
+| `output_socket` | `127.0.0.1:5571` (PUSH) |
+
+### Fast Detector — thresholds externalizados (DAY 12)
+
+> Principio Via Appia Quality: sin thresholds hardcodeados, el JSON manda.
+
+**Activación (cualquier condición activa el detector):**
+
+| Condición | Umbral |
+|---|---|
+| `external_ips_30s` | > 15 IPs en 30s |
+| `smb_diversity` | > 10 conexiones SMB distintas |
+| `dns_entropy` | > 2.5 bits |
+| `failed_dns_ratio` | > 0.30 |
+| `upload_download_ratio` | > 3.0 |
+| `burst_connections` | > 50 conexiones en burst |
+| `unique_destinations_30s` | > 30 destinos únicos en 30s |
+
+**Scores:**
+
+| Nivel | Score |
+|---|---|
+| `high_threat` | 0.95 |
+| `suspicious` | 0.70 |
+| `alert` | 0.75 |
+
+**Clasificación:**
+- `high_threat` si: `external_ips_30s > umbral` OR `smb_diversity > umbral`
+- `suspicious` si: `dns_entropy > umbral` OR `burst_connections > umbral`
+
+### ML Defender — thresholds de detección
+
+| Detector | Umbral |
+|---|---|
+| `ddos` | 0.85 |
+| `ransomware` | 0.90 |
+| `traffic` | 0.80 |
+| `internal` | 0.85 |
+
+Rango válido: `[0.5, 0.99]`. Fallback: `0.75`.
+
+### Buffers y ventanas temporales
+
+| Parámetro | Valor |
+|---|---|
+| `flow_tracking_window_seconds` | 300 |
+| `feature_aggregation_window_seconds` | 30 |
+| `max_flows_per_window` | 100.000 |
+| `flow_state_buffer_entries` | 500.000 |
+| `ring_buffer_entries` | 65.536 |
+
+### Logging
+
+- **Path:** `/vagrant/logs/lab/sniffer.log`
+- **Level:** `INFO`
+- **Rotación:** 10 ficheros × 200 MB
+
+---
+
+## ml_detector_config.json
+
+**Path:** `ml-detector/config/ml_detector_config.json`
+**Versión actual:** `1.0.0`
+**Componente:** `cpp_ml_detector_tricapa`
+
+### Arquitectura tricapa
+
+```
+Nivel 1 — Detección general
+    └── Random Forest, 23 features, ONNX (level1_attack_detector.onnx)
+         threshold: 0.65
+
+Nivel 2 — Clasificadores especializados (embebidos C++20)
+    ├── DDoS Binary Detector    — 10 features, < 50μs, threshold: 0.70
+    └── Ransomware Detector     — 10 features, < 55μs, threshold: 0.75
+
+Nivel 3 — Especialización avanzada (embebidos C++20)
+    ├── Traffic Classifier      — 10 features, < 50μs, threshold: 0.60
+    └── Internal Anomaly        — 10 features, < 48μs, threshold: 0.65
+```
+
+### Sockets ZMQ
+
+| Socket | Endpoint | Tipo | Rol |
+|---|---|---|---|
+| Input | `tcp://127.0.0.1:5571` | PULL | Recibe de sniffer |
+| Output | `tcp://0.0.0.0:5572` | PUB | Publica a firewall y RAG |
+
+### Modelos Nivel 1 (ONNX)
+
+| Parámetro | Valor |
+|---|---|
+| `model_file` | `models/production/level1/level1_attack_detector.onnx` |
+| `scaler_file` | `models/production/level1/scaler.json` |
+| `features_count` | 23 |
+| `requires_scaling` | `true` |
+| `timeout_ms` | 10 |
+
+### Modelos Nivel 2 (C++20 embebidos)
+
+**DDoS Binary Detector:**
+
+Features: `syn_ack_ratio`, `packet_symmetry`, `source_ip_dispersion`, `protocol_anomaly_score`, `packet_size_entropy`, `traffic_amplification_factor`, `flow_completion_rate`, `geographical_concentration`, `traffic_escalation_rate`, `resource_saturation_score`
+
+**Ransomware Detector Embedded:**
+
+Features: `io_intensity`, `entropy`, `resource_usage`, `network_activity`, `file_operations`, `process_anomaly`, `temporal_pattern`, `access_frequency`, `data_volume`, `behavior_consistency`
+
+### Modelos Nivel 3 (C++20 embebidos)
+
+**Traffic Classifier:** `packet_rate`, `connection_rate`, `tcp_udp_ratio`, `avg_packet_size`, `port_entropy`, `flow_duration_std`, `src_ip_entropy`, `dst_ip_concentration`, `protocol_variety`, `temporal_consistency`
+
+**Internal Anomaly Detector:** `internal_connection_rate`, `service_port_consistency`, `protocol_regularity`, `packet_size_consistency`, `connection_duration_std`, `lateral_movement_score`, `service_discovery_patterns`, `data_exfiltration_indicators`, `temporal_anomaly_score`, `access_pattern_entropy`
+
+### Scoring y divergencia
+
+| Parámetro | Valor | Significado |
+|---|---|---|
+| `divergence_warn_threshold` | 0.30 | Divergencia fast/ML que genera warning |
+| `divergence_high_threshold` | 0.40 | Divergencia alta — análisis RAG |
+| `malicious_threshold` | 0.70 | Score mínimo para clasificar MALICIOUS |
+| `requires_rag_threshold` | 0.85 | Score que dispara análisis RAG |
+
+### CSV writer (eventos para RAG)
+
+| Parámetro | Valor |
+|---|---|
+| `base_dir` | `/vagrant/logs/ml-detector/events/` |
+| `min_score_threshold` | 0.50 |
+| `max_events_per_file` | 10.000 |
+
+### Logging
+
+- **Path:** `/vagrant/logs/lab/detector.log`
+- **Level:** `INFO`
+- **Rotación:** 10 ficheros × 200 MB
+
+---
+
+## firewall.json
+
+**Path:** `firewall-acl-agent/config/firewall.json`
+**Versión actual:** `1.2.1`
+**Componente:** `firewall-acl-agent`
+
+### Rol en el pipeline
+
+El firewall-acl-agent es el **endpoint final** del pipeline. Solo **descifra** y **descomprime** — no cifra ni comprime salidas (no tiene downstream).
+
+**Flujo de procesamiento:**
+```
+1. Recibir mensaje ZMQ de ml-detector (cifrado + comprimido)  → puerto 5572
+2. Descifrar con ChaCha20-Poly1305 (token desde etcd)
+3. Descomprimir con LZ4
+4. Parsear Protobuf (Detection/DetectionBatch)
+5. Aplicar reglas IPTables / IPSet
+```
+
+### Socket ZMQ
+
+| Parámetro | Valor |
+|---|---|
+| `endpoint` | `tcp://localhost:5572` |
+| `socket_type` | SUB |
+| `recv_timeout_ms` | 1000 |
+
+### IPSets
+
+| Set | Nombre | Max elementos | Timeout |
+|---|---|---|---|
+| Blacklist | `ml_defender_blacklist_test` | 1000 | 3600s |
+| Whitelist | `ml_defender_whitelist` | 500 | 0 (permanente) |
+
+**IPTables:** cadena `ML_DEFENDER_TEST`, política default `ACCEPT`.
+
+```
+iptables -A INPUT -m set --match-set ml_defender_blacklist_test src -j DROP
+```
+
+### Validación de IPs
+
+Rangos permitidos para bloqueo:
+
+```
+192.168.0.0/16
+10.0.0.0/8
+172.16.0.0/12
+```
+
+`block_localhost: false` — nunca bloquear localhost.
+
+### Procesamiento en batch
+
+| Parámetro | Valor |
+|---|---|
+| `batch_size_threshold` | 10 |
+| `batch_time_threshold_ms` | 1000 |
+| `min_confidence` | 0.50 |
+
+### CSV batch logger (para RAG)
+
+- **Output:** `/vagrant/logs/firewall_logs/`
+- **Batch size:** 100 eventos
+- **Batch timeout:** 5s
+- Las CSVs incluyen firma HMAC para detección de manipulación
+
+### Logging
+
+- **Path:** `/vagrant/logs/lab/firewall-agent.log`
+- **Level:** `debug`
+- **Rotación:** 5 ficheros × 10 MB
+
+---
+
+## rag-ingester.json
+
+**Path:** `rag-ingester/config/rag-ingester.json`
+**Versión actual:** `0.1.0`
+**Componente:** `rag-ingester`
+
+### Rol en el pipeline
+
+Consume eventos de dos fuentes CSV (ml-detector + firewall), genera embeddings y los indexa en FAISS para consultas del rag-security.
+
+### Fuentes de datos
+
+| Fuente | Path | HMAC |
+|---|---|---|
+| ML Detector events | `/vagrant/logs/ml-detector/events/` | clave en `csv_ml_detector_hmac_key_hex` |
+| Firewall blocks | `/vagrant/logs/firewall_logs/firewall_blocks.csv` | clave en `csv_firewall_hmac_key_hex` |
+
+Parámetro `replay_on_start: true` — re-procesa CSVs existentes al arrancar.
+
+### Embedders (modelos ONNX)
+
+| Embedder | Modelo ONNX | Input dim | Output dim | Uso |
+|---|---|---|---|---|
+| `chronos` | `chronos.onnx` | 83 | 512 | Patrones temporales |
+| `sbert` | `sbert.onnx` | 83 | 384 | Semántica de seguridad |
+| `attack` | `attack.onnx` | 83 | 256 | Clasificación de ataques |
+
+`attack` tiene `benign_sample_rate: 0.1` — submuestreo de tráfico benigno.
+
+### PCA — reducción de dimensionalidad (anti-curse)
+
+| Embedder | Modelo PCA | Dim entrada | Dim salida |
+|---|---|---|---|
+| chronos | `chronos_512_128.faiss` | 512 | 128 |
+| sbert | `sbert_384_96.faiss` | 384 | 96 |
+| attack | `attack_256_64.faiss` | 256 | 64 |
+
+### FAISS
+
+| Parámetro | Valor |
+|---|---|
+| `index_type` | `Flat` |
+| `metric` | `L2` |
+| `persist_path` | `/shared/faiss_indexes` |
+| `checkpoint_interval_events` | 1000 |
+
+### Health monitoring
+
+| Threshold | Valor | Acción |
+|---|---|---|
+| `cv_warning_threshold` | 0.20 | Warning en logs |
+| `cv_critical_threshold` | 0.15 | Alerta crítica a etcd |
+
+---
+
+## rag-config.json
+
+**Path:** `rag/config/rag-config.json`
+**Componente:** `rag-security`
+
+### Modelo LLM
+
+| Parámetro | Valor |
+|---|---|
+| `model_name` | `tinyllama-1.1b-chat-v1.0.Q4_0.gguf` |
+| `embedding_dimension` | 512 |
+| `context_size` | 2048 |
+| `gpu_layers` | 0 (CPU only) |
+
+### Dimensiones FAISS (deben coincidir con rag-ingester tras PCA)
+
+| Índice | Dimensión |
+|---|---|
+| `chronos_dim` | 128 |
+| `sbert_dim` | 96 |
+| `attack_dim` | 64 |
+
+### Capacidades habilitadas
+
+```
+component_management  — gestión del ciclo de vida de componentes
+config_validation     — validación de configuración JSON
+pipeline_control      — control del pipeline completo
+embedder_system       — gestión del sistema de embeddings
+faiss_search          — consultas FAISS
+```
+
+### Transporte
+
+| Parámetro | Valor |
+|---|---|
+| `compression` | `lz4` |
+| `encryption` | `AES-256-CBC` |
+| `requires_encryption` | `true` |
+| `security_level` | 3 |
+
+### Logging
+
+- **Path:** `/vagrant/logs/rag.log`
+- **Level:** `info`
+- **Mode:** append
+
+---
+
+## Convenciones comunes
+
+### Puertos ZMQ del pipeline
+
+```
+sniffer  →[5571 PUSH/PULL]→  ml-detector  →[5572 PUB/SUB]→  firewall-acl-agent
+                                                          └→  rag-security (subscriber)
+```
+
+### Etcd — paths de configuración
+
+| Componente | Config path | Crypto token path |
+|---|---|---|
+| sniffer | `/config/sniffer` | `/crypto/sniffer/tokens` |
+| ml-detector | `/config/ml-detector` | `/crypto/ml-detector/tokens` |
+| firewall | `/config/firewall` | `/crypto/firewall/tokens` |
+
+### Sentinel value
+
+`MISSING_FEATURE_SENTINEL = -9999.0f` — valor matemáticamente inalcanzable que indica feature ausente. Nunca usar `0.0f` ni `0.5f` para indicar ausencia.
+
+### Schema version
+
+`schema_version = 31` en protobuf equivale a `v3.1.0` semántico. Todos los componentes deben validar esta versión al procesar eventos.
+
+### Rotación de logs
+
+Todos los componentes siguen el patrón:
+- Path: `/vagrant/logs/lab/<componente>.log`
+- Tamaño máximo: 200 MB (10 MB en firewall)
+- Backup count: 10 (5 en firewall)
+
+---
+
+## Flujo de datos entre componentes
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    ML DEFENDER PIPELINE                      │
+│                                                             │
+│  ┌──────────┐   proto+lz4     ┌─────────────┐              │
+│  │  sniffer  │ ──[5571 PUSH]──▶ ml-detector  │              │
+│  │  eth1/2   │  +chacha20     │  3 niveles   │              │
+│  └──────────┘                 └──────┬───────┘              │
+│                                      │ proto+lz4+chacha20   │
+│                                      │ [5572 PUB]           │
+│                           ┌──────────┴──────────┐           │
+│                           ▼                     ▼           │
+│                  ┌──────────────┐      ┌─────────────────┐  │
+│                  │  firewall-   │      │  rag-security   │  │
+│                  │  acl-agent   │      │  (subscriber)   │  │
+│                  │  iptables/   │      │  TinyLlama      │  │
+│                  │  ipset       │      └────────┬────────┘  │
+│                  └──────────────┘               │           │
+│                         │ CSV+HMAC              │ FAISS     │
+│                         ▼                       ▼           │
+│                  ┌──────────────────────────────────────┐   │
+│                  │           rag-ingester               │   │
+│                  │  chronos + sbert + attack embedders  │   │
+│                  └──────────────────────────────────────┘   │
+│                                                             │
+│  ┌──────────────┐                                           │
+│  │  etcd-server │ ← coordinación, crypto tokens, heartbeat  │
+│  └──────────────┘                                           │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+*Co-authored-by: Alonso Isidoro Román + Claude (Anthropic)*
+*DAY 92 — 20 marzo 2026*

--- a/docs/contracts/Protobuf contracts.md
+++ b/docs/contracts/Protobuf contracts.md
@@ -1,0 +1,377 @@
+# Protobuf Contract — `network_security.proto`
+
+> **Fuente canónica:** `protobuf/network_security.proto`
+> **Schema version:** `v3.1.0` (`schema_version = 31`)
+> **Última revisión:** DAY 91 — 19 marzo 2026
+
+---
+
+## Índice
+
+1. [Filosofía de diseño](#filosofía-de-diseño)
+2. [Arquitectura de mensajes](#arquitectura-de-mensajes)
+3. [Mensaje principal: NetworkSecurityEvent](#mensaje-principal-networksecurityevent)
+4. [Features de red: NetworkFeatures](#features-de-red-networkfeatures)
+5. [Detectores embebidos PHASE 1](#detectores-embebidos-phase-1)
+6. [Detección avanzada de ransomware: RansomwareFeatures](#detección-avanzada-de-ransomware-ransomwarefeatures)
+7. [Sistema dual-score](#sistema-dual-score)
+8. [Provenance multi-engine (ADR-002)](#provenance-multi-engine-adr-002)
+9. [Geolocalización](#geolocalización)
+10. [Pipeline y nodos distribuidos](#pipeline-y-nodos-distribuidos)
+11. [Mensajes de firewall](#mensajes-de-firewall)
+12. [Ambigüedades documentadas](#ambigüedades-documentadas)
+13. [Campos reservados para features SMB (DAY 92+)](#campos-reservados-para-features-smb-day-92)
+
+---
+
+## Filosofía de diseño
+
+- **Todo o nada** — sin campos legacy confusos, sin compatibilidad hacia atrás deliberada
+- **`schema_version = 31`** corresponde a la versión semántica `v3.1.0`
+- **PHASE 1** agrupa los 4 detectores embebidos C++20 (DDoS, Ransomware, Traffic, Internal)
+- **PHASE 2** (enterprise/roadmap) incluye modelos ONNX externos y `RansomwareFeatures` (20 campos)
+
+---
+
+## Arquitectura de mensajes
+
+```
+NetworkSecurityEvent  ← mensaje raíz que viaja por el pipeline
+├── NetworkFeatures           (83+ features ML del flujo)
+│   ├── DDoSFeatures          (embebido, 10 features, PHASE 1)
+│   ├── RansomwareEmbeddedFeatures  (embebido, 10 features, PHASE 1)
+│   ├── TrafficFeatures       (embebido, 10 features, PHASE 1)
+│   ├── InternalFeatures      (embebido, 10 features, PHASE 1)
+│   └── RansomwareFeatures    (20 features, PHASE 2 enterprise — ver §Ambigüedades)
+├── GeoEnrichment             (geolocalización 3-punto: sniffer/src/dst)
+├── TricapaMLAnalysis         (resultados de los 3 niveles ML)
+├── DetectionProvenance       (trazabilidad multi-engine, ADR-002)
+├── DecisionMetadata          (divergencia fast vs ML, prioridad RAG)
+├── PipelineTracking          (timestamps y métricas por etapa)
+├── RAGAnalysis               (análisis contextual TinyLlama)
+└── HumanInTheLoopReview      (feedback analista humano)
+```
+
+---
+
+## Mensaje principal: NetworkSecurityEvent
+
+| Campo | Tipo | Nº | Descripción |
+|---|---|---|---|
+| `event_id` | string | 1 | UUID único del evento |
+| `event_timestamp` | Timestamp | 2 | Marca temporal del evento |
+| `originating_node_id` | string | 3 | ID del nodo que origina el evento |
+| `network_features` | NetworkFeatures | 4 | Features ML del flujo de red |
+| `geo_enrichment` | GeoEnrichment | 5 | Enriquecimiento geográfico |
+| `time_window` | TimeWindow | 6 | Ventana temporal del evento |
+| `ml_analysis` | TricapaMLAnalysis | 7 | Análisis tricapa ML |
+| `additional_model_predictions` | repeated ModelPrediction | 8 | Predicciones adicionales |
+| `capturing_node` | DistributedNode | 9 | Nodo capturador |
+| `pipeline_tracking` | PipelineTracking | 10 | Trazabilidad de pipeline |
+| `rag_analysis` | RAGAnalysis | 11 | Análisis RAG |
+| `human_review` | HumanInTheLoopReview | 12 | Revisión humana |
+| `overall_threat_score` | double | 15 | Score global 0.0–1.0 |
+| `final_classification` | string | 16 | `BENIGN` / `SUSPICIOUS` / `MALICIOUS` |
+| `threat_category` | string | 17 | `DDOS` / `RANSOMWARE` / `NORMAL` / etc. |
+| `correlation_id` | string | 20 | ID de correlación entre eventos |
+| `related_event_ids` | repeated string | 21 | IDs de eventos relacionados |
+| `event_chain_id` | string | 22 | Cadena de ataque |
+| `schema_version` | uint32 | 25 | `31` = v3.1.0 |
+| `custom_metadata` | map<string,string> | 26 | Metadatos custom |
+| `event_tags` | repeated string | 27 | Tags del evento |
+| `protobuf_version` | string | 28 | `"3.1.0"` |
+| `fast_detector_score` | double | 29 | Score heurístico capa 1 (0.0–1.0) |
+| `ml_detector_score` | double | 30 | Score ML capa 3 (0.0–1.0) |
+| `authoritative_source` | DetectorSource | 31 | Quién determinó la amenaza final |
+| `fast_detector_triggered` | bool | 32 | ¿Se activó el Fast Detector? |
+| `fast_detector_reason` | string | 33 | Razón de activación |
+| `decision_metadata` | DecisionMetadata | 34 | Metadatos de decisión para RAG |
+| `provenance` | DetectionProvenance | 35 | Trazabilidad multi-engine (ADR-002) |
+
+---
+
+## Features de red: NetworkFeatures
+
+### Identificación del flujo (campos 1–10)
+
+| Campo | Tipo | Nº | Descripción |
+|---|---|---|---|
+| `source_ip` | string | 1 | IP origen |
+| `destination_ip` | string | 2 | IP destino |
+| `source_port` | uint32 | 3 | Puerto origen |
+| `destination_port` | uint32 | 4 | Puerto destino |
+| `protocol_number` | uint32 | 5 | Número de protocolo |
+| `protocol_name` | string | 6 | Nombre del protocolo |
+| `interface_mode` | uint32 | 7 | `0`=disabled, `1`=host-based, `2`=gateway |
+| `is_wan_facing` | bool | 8 | `true`=WAN, `false`=LAN |
+| `source_ifindex` | uint32 | 9 | Índice de interfaz de red |
+| `source_interface` | string | 10 | Nombre de interfaz (`eth0`, `eth1`) |
+
+### Timing (campos 11–13)
+
+| Campo | Tipo | Nº | Descripción |
+|---|---|---|---|
+| `flow_start_time` | Timestamp | 11 | Inicio del flujo |
+| `flow_duration` | Duration | 12 | Duración del flujo |
+| `flow_duration_microseconds` | uint64 | 13 | Duración en microsegundos |
+
+### Estadísticas de paquetes (campos 14–17)
+
+| Campo | Tipo | Nº | Descripción |
+|---|---|---|---|
+| `total_forward_packets` | uint64 | 14 | Paquetes forward |
+| `total_backward_packets` | uint64 | 15 | Paquetes backward |
+| `total_forward_bytes` | uint64 | 16 | Bytes forward |
+| `total_backward_bytes` | uint64 | 17 | Bytes backward |
+
+### Estadísticas de longitud — Forward (campos 20–23) / Backward (30–33)
+
+Incluyen `_max`, `_min`, `_mean`, `_std` para ambas direcciones.
+
+### Velocidades y ratios (campos 40–47)
+
+`flow_bytes_per_second`, `flow_packets_per_second`, `forward/backward_packets_per_second`, `download_upload_ratio`, tamaños medios.
+
+### Inter-arrival times (campos 50–63)
+
+Estadísticas de tiempo entre llegadas para flujo (50–53), forward (54–58), backward (59–63).
+
+### TCP Flags counts (campos 70–81)
+
+`fin`, `syn`, `rst`, `psh`, `ack`, `urg`, `cwe`, `ece` + versiones direccionales forward/backward para `psh` y `urg`.
+
+### Headers y bulk transfer (campos 85–92)
+
+Longitudes de cabecera y estadísticas de transferencia en bulk para ambas direcciones.
+
+### Estadísticas adicionales (campos 95–99, 104–105)
+
+`min/max/mean/std/variance` de longitud de paquetes, `active_mean`, `idle_mean`.
+
+### Features para modelos ML (campos 100–103)
+
+| Campo | Tipo | Nº | Descripción |
+|---|---|---|---|
+| `ddos_features` | repeated double | 100 | 83 features para DDoS |
+| `ransomware_features` | repeated double | 101 | 83 features ransomware enterprise (PHASE 2) |
+| `general_attack_features` | repeated double | 102 | 23 features RF general |
+| `internal_traffic_features` | repeated double | 103 | 4–5 features tráfico interno |
+
+### Detectores embebidos PHASE 1 (campos 112–115)
+
+| Campo | Tipo | Nº | Descripción |
+|---|---|---|---|
+| `ddos_embedded` | DDoSFeatures | 112 | 10 features DDoS embebido |
+| `ransomware_embedded` | RansomwareEmbeddedFeatures | 113 | 10 features ransomware PHASE 1 |
+| `traffic_classification` | TrafficFeatures | 114 | 10 features clasificación tráfico |
+| `internal_anomaly` | InternalFeatures | 115 | 10 features anomalía interna |
+
+### Metadatos (campos 110–111)
+
+`custom_features` y `feature_metadata` como mapas clave-valor.
+
+---
+
+## Detectores embebidos PHASE 1
+
+### DDoSFeatures (mensaje embebido en campo 112)
+
+| Campo | Nº | Rango esperado |
+|---|---|---|
+| `syn_ack_ratio` | 1 | 0.0–1.0 |
+| `packet_symmetry` | 2 | 0.0–1.0 |
+| `source_ip_dispersion` | 3 | 0.0–1.0 |
+| `protocol_anomaly_score` | 4 | 0.0–1.0 |
+| `packet_size_entropy` | 5 | 0.0–8.0 (bits) |
+| `traffic_amplification_factor` | 6 | ≥ 1.0 |
+| `flow_completion_rate` | 7 | 0.0–1.0 |
+| `geographical_concentration` | 8 | 0.0–1.0 |
+| `traffic_escalation_rate` | 9 | 0.0–1.0 |
+| `resource_saturation_score` | 10 | 0.0–1.0 |
+
+### RansomwareEmbeddedFeatures (mensaje embebido en campo 113)
+
+10 features de comportamiento: `io_intensity`, `entropy`, `resource_usage`, `network_activity`, `file_operations`, `process_anomaly`, `temporal_pattern`, `access_frequency`, `data_volume`, `behavior_consistency`.
+
+### TrafficFeatures (campo 114) / InternalFeatures (campo 115)
+
+Ver proto fuente para lista completa. Ambos con 10 features especializadas.
+
+---
+
+## Detección avanzada de ransomware: RansomwareFeatures
+
+> **Nota:** `RansomwareFeatures` es el mensaje de **20 features** para detección avanzada enterprise (**PHASE 2**, caja doméstica). No confundir con `RansomwareEmbeddedFeatures` (10 features, **PHASE 1**, campo 113 de `NetworkFeatures`). Ambos coexisten para migración gradual sin breaking changes. Ver campo `ransomware` (nº 106) en `NetworkFeatures`.
+
+| Categoría | Campos |
+|---|---|
+| **C&C Communication** | `dns_query_entropy`, `new_external_ips_30s`, `dns_query_rate_per_min`, `failed_dns_queries_ratio`, `tls_self_signed_cert_count`, `non_standard_port_http_count` |
+| **Lateral Movement** | `smb_connection_diversity`, `rdp_failed_auth_count`, `new_internal_connections_30s`, `port_scan_pattern_score` |
+| **Exfiltration** | `upload_download_ratio_30s`, `burst_connections_count`, `unique_destinations_30s`, `large_upload_sessions_count` |
+| **Behavioral** | `nocturnal_activity_flag`, `connection_rate_stddev`, `protocol_diversity_score`, `avg_flow_duration_seconds`, `tcp_rst_ratio`, `syn_without_ack_ratio` |
+
+---
+
+## Sistema dual-score
+
+Introducido en DAY 13 (diciembre 2025). Preserva scores de ambos detectores para validación F1 contra CTU-13.
+
+### DetectorSource (enum)
+
+| Valor | Código | Significado |
+|---|---|---|
+| `DETECTOR_SOURCE_UNKNOWN` | 0 | Sin información |
+| `DETECTOR_SOURCE_FAST_ONLY` | 1 | Solo Fast Detector activado |
+| `DETECTOR_SOURCE_ML_ONLY` | 2 | Solo ML Detector activado |
+| `DETECTOR_SOURCE_FAST_PRIORITY` | 3 | Ambos activos, Fast score mayor |
+| `DETECTOR_SOURCE_ML_PRIORITY` | 4 | Ambos activos, ML score mayor |
+| `DETECTOR_SOURCE_CONSENSUS` | 5 | Ambos activos, scores similares |
+| `DETECTOR_SOURCE_DIVERGENCE` | 6 | Divergencia significativa (> 0.30) |
+
+### DecisionMetadata
+
+| Campo | Tipo | Descripción |
+|---|---|---|
+| `score_divergence` | double | `\|fast_score - ml_score\|` |
+| `divergence_reason` | string | Explicación de divergencia |
+| `requires_rag_analysis` | bool | Enviar a RAG para investigación |
+| `investigation_priority` | string | `LOW` / `MEDIUM` / `HIGH` / `CRITICAL` |
+| `anomaly_flags` | repeated string | Flags específicos detectados |
+| `confidence_level` | double | Confianza en la decisión (0.0–1.0) |
+
+**Umbrales de scoring (ml_detector_config.json):**
+
+| Parámetro | Valor |
+|---|---|
+| `divergence_warn_threshold` | 0.30 |
+| `divergence_high_threshold` | 0.40 |
+| `malicious_threshold` | 0.70 |
+| `requires_rag_threshold` | 0.85 |
+
+---
+
+## Provenance multi-engine (ADR-002)
+
+Introducido en DAY 37 (enero 2026). Registra el veredicto de todos los engines de detección.
+
+### EngineVerdict
+
+| Campo | Tipo | Descripción |
+|---|---|---|
+| `engine_name` | string | `"fast-path-sniffer"`, `"random-forest"`, `"cnn-secondary"` |
+| `classification` | string | `"Benign"`, `"DDoS"`, `"Ransomware"`, etc. |
+| `confidence` | float | 0.0–1.0 |
+| `reason_code` | string | `"SIG_MATCH"`, `"STAT_ANOMALY"`, `"PCA_OUTLIER"` |
+| `timestamp_ns` | uint64 | Timestamp en nanosegundos |
+
+### DetectionProvenance
+
+| Campo | Tipo | Descripción |
+|---|---|---|
+| `verdicts` | repeated EngineVerdict | Todos los veredictos de engines |
+| `global_timestamp_ns` | uint64 | Momento de la decisión final |
+| `final_decision` | string | `"ALLOW"` / `"DROP"` / `"ALERT"` |
+| `discrepancy_score` | float | 0.0 (total acuerdo) – 1.0 (máxima divergencia) |
+| `logic_override` | string | Si RAG/humano forzó la decisión |
+| `discrepancy_reason` | string | Explicación si los engines divergen |
+
+---
+
+## Geolocalización
+
+### GeoEnrichment
+
+Análisis geográfico en tres puntos: nodo sniffer, IP origen, IP destino.
+
+**Análisis calculados:**
+
+| Campo | Descripción |
+|---|---|
+| `source_destination_distance_km` | Distancia geográfica src→dst |
+| `source_destination_same_country` | ¿Mismo país? |
+| `distance_category` | `local` / `regional` / `national` / `international` |
+| `geographic_anomaly_score` | 0.0–1.0 |
+| `suspicious_geographic_pattern` | Flag booleano |
+
+**Descubrimiento de IP pública** (para IPs privadas via `ip_discovery_service`).
+
+---
+
+## Pipeline y nodos distribuidos
+
+### PipelineTracking — timestamps por etapa
+
+```
+packet_captured_at → features_extracted_at → geoip_enriched_at
+    → ml_analyzed_at → threat_detected_at → action_taken_at
+```
+
+### DistributedNode — roles
+
+| Rol | Componente ML Defender |
+|---|---|
+| `PACKET_SNIFFER` (0) | sniffer |
+| `ML_ANALYZER` (3) | ml-detector |
+| `THREAT_DETECTOR` (4) | ml-detector (fast path) |
+| `FIREWALL_CONTROLLER` (5) | firewall-acl-agent |
+| `DATA_AGGREGATOR` (6) | rag-ingester |
+| `CLUSTER_COORDINATOR` (8) | etcd-server |
+
+---
+
+## Mensajes de firewall
+
+### Detection (mensaje simple para firewall-acl-agent)
+
+| Campo | Tipo | Descripción |
+|---|---|---|
+| `src_ip` | string | IP a bloquear |
+| `type` | DetectionType | `DDOS`/`RANSOMWARE`/`SUSPICIOUS_TRAFFIC`/`INTERNAL_THREAT` |
+| `confidence` | float | Score de confianza |
+| `timestamp` | uint64 | Timestamp del evento |
+| `action` | string | `"BLOCK"` / `"ALERT"` / `"LOG"` |
+| `duration_seconds` | uint32 | Duración del bloqueo (`0` = permanente) |
+
+`DetectionBatch` agrupa múltiples `Detection` para procesamiento en lote.
+
+---
+
+## Ambigüedades documentadas
+
+### RansomwareFeatures vs RansomwareEmbeddedFeatures
+
+**Esta dualidad es intencional.** Coexisten para migración gradual sin breaking changes:
+
+| Mensaje | Campos | Campo en NetworkFeatures | Fase |
+|---|---|---|---|
+| `RansomwareEmbeddedFeatures` | 10 | `ransomware_embedded` (nº 113) | **PHASE 1** — activo en producción |
+| `RansomwareFeatures` | 20 | `ransomware` (nº 106) | **PHASE 2** — enterprise/roadmap |
+
+---
+
+## Campos reservados para features SMB (DAY 92+)
+
+> **Pendiente de implementación en DAY 92** — rama `feature/smb-detection-features`
+
+Se añadirá el mensaje `SMBScanFeatures` para detección WannaCry/NotPetya:
+
+```protobuf
+// SMBScanFeatures — features de escaneo SMB (WannaCry/NotPetya)
+// SYN-1, SYN-2: rst_ratio y syn_ack_ratio (P1 — DAY 92)
+// SYN-8b: flow_duration_min_ms (P2 — DAY 97+)
+message SMBScanFeatures {
+    optional float rst_ratio            = 1;  // RST/SYN — WannaCry > 0.70
+    optional float syn_ack_ratio        = 2;  // ACK/SYN — WannaCry < 0.10
+    optional float flow_duration_min_ms = 3;  // P2 — flujos WannaCry < 50ms
+}
+```
+
+**Umbrales de referencia WannaCry:**
+- `rst_ratio > 0.70` → señal maligna
+- `syn_ack_ratio < 0.10` → señal maligna
+- `syn_flag_count == 0` → sentinel `MISSING_FEATURE_SENTINEL = -9999.0f`
+
+---
+
+*Co-authored-by: Alonso Isidoro Román + Claude (Anthropic)*
+*DAY 92 — 20 marzo 2026*

--- a/docs/contracts/Rag security commands.md
+++ b/docs/contracts/Rag security commands.md
@@ -1,0 +1,327 @@
+# Comandos del rag-security
+
+> **Fuente canónica:** `rag/config/command_whitelist.json`
+> **Componente:** `rag-security` (puerto HTTP `8080`, protocolo ZMQ cifrado)
+> **Última revisión:** DAY 92 — 20 marzo 2026
+
+---
+
+## Índice
+
+1. [Arquitectura de seguridad](#arquitectura-de-seguridad)
+2. [Comandos permitidos](#comandos-permitidos)
+3. [Patrones permitidos](#patrones-permitidos)
+4. [Claves restringidas](#claves-restringidas)
+5. [Límites y validación](#límites-y-validación)
+6. [Referencia de comandos](#referencia-de-comandos)
+7. [Ejemplos de uso](#ejemplos-de-uso)
+8. [Añadir nuevos comandos](#añadir-nuevos-comandos)
+
+---
+
+## Arquitectura de seguridad
+
+El rag-security implementa un **whitelist estricto** — solo se ejecutan comandos explícitamente autorizados.
+
+```
+Cliente → [ZMQ cifrado AES-256-CBC + lz4] → rag-security
+                                                 │
+                                                 ▼
+                                     command_whitelist.json
+                                                 │
+                                    ┌────────────┴────────────┐
+                                    │  ¿comando en whitelist?  │
+                                    └────────────┬────────────┘
+                                         Sí ▼       No ▼
+                                       Ejecutar    REJECT (403)
+```
+
+**Parámetros de seguridad:**
+
+| Parámetro | Valor |
+|---|---|
+| `security_level` | 3 (máximo) |
+| `whitelist_commands` | `true` |
+| `requires_encryption` | `true` |
+| `max_query_length` | 1000 caracteres |
+
+---
+
+## Comandos permitidos
+
+Lista completa de comandos autorizados en `allowed_commands`:
+
+| Comando | Categoría | Descripción |
+|---|---|---|
+| `status` | Sistema | Estado general del componente rag-security |
+| `validate` | Validación | Validar configuración o integridad del sistema |
+| `encryption_test` | Seguridad | Verificar que el cifrado funciona correctamente |
+| `pipeline_status` | Pipeline | Estado de todos los componentes del pipeline |
+| `start_component` | Gestión | Iniciar un componente del pipeline |
+| `stop_component` | Gestión | Detener un componente del pipeline |
+| `get_config` | Configuración | Obtener configuración actual de un componente |
+| `update_config` | Configuración | Actualizar configuración de un componente |
+| `show_rag_config` | RAG | Mostrar configuración actual del sistema RAG |
+| `set_rag_setting` | RAG | Modificar un parámetro del sistema RAG |
+| `get_rag_capabilities` | RAG | Listar capacidades disponibles del sistema RAG |
+
+---
+
+## Patrones permitidos
+
+El whitelist también acepta comandos que coincidan con estos patrones regex:
+
+| Patrón | Comandos que acepta |
+|---|---|
+| `^status.*` | `status`, `status_detail`, `status_ml`, etc. |
+| `^validate.*` | `validate`, `validate_config`, `validate_proto`, etc. |
+| `^encryption.*` | `encryption_test`, `encryption_status`, etc. |
+| `^pipeline.*` | `pipeline_status`, `pipeline_health`, `pipeline_restart`, etc. |
+| `^start.*` | `start_component`, `start_sniffer`, `start_detector`, etc. |
+| `^stop.*` | `stop_component`, `stop_sniffer`, etc. |
+| `^config.*` | `config_reload`, `config_validate`, etc. |
+| `^show.*` | `show_rag_config`, `show_logs`, `show_metrics`, etc. |
+| `^set.*` | `set_rag_setting`, `set_log_level`, etc. |
+| `^get.*` | `get_config`, `get_rag_capabilities`, `get_metrics`, etc. |
+
+> **Nota:** Los patrones son evaluados **después** de la lista `allowed_commands`. Un comando es válido si aparece en la lista explícita **o** coincide con algún patrón.
+
+---
+
+## Claves restringidas
+
+Las siguientes claves **nunca** deben aparecer en los parámetros de un comando. Su presencia provoca rechazo inmediato:
+
+| Clave restringida | Razón |
+|---|---|
+| `password` | Credenciales de acceso |
+| `secret` | Secretos de configuración |
+| `private_key` | Clave privada criptográfica |
+| `encryption_seed` | Seed ChaCha20 — dato crítico de seguridad |
+
+Estas claves están protegidas independientemente del comando que se use.
+
+---
+
+## Límites y validación
+
+| Parámetro | Límite | Comportamiento al exceder |
+|---|---|---|
+| `max_query_length` | 1000 caracteres | REJECT |
+| Claves restringidas | Lista fija | REJECT inmediato |
+| Cifrado | Requerido | Sin cifrado → conexión rechazada |
+
+---
+
+## Referencia de comandos
+
+### `status`
+
+Devuelve el estado operacional del rag-security.
+
+```json
+{
+  "command": "status"
+}
+```
+
+Respuesta esperada: estado del servidor LLM (TinyLlama), índices FAISS cargados, conexión a etcd.
+
+---
+
+### `pipeline_status`
+
+Devuelve el estado de todos los componentes registrados en etcd.
+
+```json
+{
+  "command": "pipeline_status"
+}
+```
+
+Respuesta esperada: lista de componentes con su estado (`ACTIVE`, `ERROR`, `STARTING`, etc.) y último heartbeat.
+
+---
+
+### `start_component` / `stop_component`
+
+Inicia o detiene un componente del pipeline.
+
+```json
+{
+  "command": "start_component",
+  "component": "sniffer"
+}
+```
+
+```json
+{
+  "command": "stop_component",
+  "component": "ml-detector"
+}
+```
+
+Componentes válidos: `sniffer`, `ml-detector`, `firewall-acl-agent`, `rag-ingester`, `rag-security`, `etcd-server`.
+
+---
+
+### `get_config` / `update_config`
+
+Obtiene o actualiza la configuración de un componente.
+
+```json
+{
+  "command": "get_config",
+  "component": "sniffer"
+}
+```
+
+```json
+{
+  "command": "update_config",
+  "component": "sniffer",
+  "key": "fast_detector.enabled",
+  "value": true
+}
+```
+
+> **Restricción:** No se pueden modificar claves en `restricted_keys`.
+
+---
+
+### `validate` / `encryption_test`
+
+```json
+{
+  "command": "validate",
+  "target": "proto_schema"
+}
+```
+
+```json
+{
+  "command": "encryption_test"
+}
+```
+
+`encryption_test` verifica el cifrado AES-256-CBC extremo a extremo.
+
+---
+
+### `show_rag_config`
+
+Devuelve la configuración activa del sistema RAG (modelo LLM, dimensiones FAISS, nivel de seguridad).
+
+```json
+{
+  "command": "show_rag_config"
+}
+```
+
+---
+
+### `set_rag_setting`
+
+Modifica un parámetro del sistema RAG en runtime.
+
+```json
+{
+  "command": "set_rag_setting",
+  "key": "log_level",
+  "value": "debug"
+}
+```
+
+---
+
+### `get_rag_capabilities`
+
+Lista las capacidades habilitadas en esta instancia:
+
+```json
+{
+  "command": "get_rag_capabilities"
+}
+```
+
+Respuesta esperada:
+```json
+{
+  "capabilities": [
+    "component_management",
+    "config_validation",
+    "pipeline_control",
+    "embedder_system",
+    "faiss_search"
+  ]
+}
+```
+
+---
+
+## Ejemplos de uso
+
+### Consulta de estado completa del pipeline
+
+```bash
+# Via ZMQ (requiere cliente con cifrado AES-256-CBC + lz4)
+zmq_client --host localhost --port 8080 \
+  --command '{"command": "pipeline_status"}'
+```
+
+### Verificación de cifrado tras cambio de keys
+
+```bash
+zmq_client --host localhost --port 8080 \
+  --command '{"command": "encryption_test"}'
+```
+
+### Consulta RAG de seguridad (análisis de amenaza)
+
+Las consultas de análisis de amenazas se envían como queries en lenguaje natural al modelo TinyLlama. El sistema recupera contexto relevante de los índices FAISS antes de generar la respuesta.
+
+```json
+{
+  "command": "get_rag_capabilities",
+  "query": "show threat analysis for suspicious SMB traffic"
+}
+```
+
+---
+
+## Añadir nuevos comandos
+
+Para añadir un nuevo comando al whitelist:
+
+1. Editar `rag/config/command_whitelist.json`
+2. Añadir el comando exacto a `allowed_commands` **o** un patrón regex a `allowed_patterns`
+3. Si el comando accede a datos sensibles, verificar que no use ninguna clave de `restricted_keys`
+4. Reiniciar rag-security para que cargue la nueva configuración
+
+```json
+{
+  "allowed_commands": [
+    "...",
+    "nuevo_comando"
+  ]
+}
+```
+
+> No se requiere recompilación. El whitelist se carga desde JSON en cada arranque.
+
+---
+
+## Mapa de capacidades vs comandos
+
+| Capacidad | Comandos relacionados |
+|---|---|
+| `component_management` | `start_component`, `stop_component` |
+| `config_validation` | `validate`, `get_config`, `update_config` |
+| `pipeline_control` | `pipeline_status`, `start_component`, `stop_component` |
+| `embedder_system` | `show_rag_config`, `set_rag_setting` |
+| `faiss_search` | Consultas de análisis RAG (lenguaje natural) |
+
+---
+
+*Co-authored-by: Alonso Isidoro Román + Claude (Anthropic)*
+*DAY 92 — 20 marzo 2026*


### PR DESCRIPTION
- docs/contracts/protobuf-contract.md: network_security.proto documentado completo con tablas, arquitectura de mensajes, dual-score, ADR-002, ambigüedades RansomwareFeatures y campos SMB pendientes DAY 92+
- docs/contracts/json-contracts.md: contratos JSON de los 5 componentes (sniffer, ml-detector, firewall, rag-ingester, rag-security) con thresholds, sockets ZMQ, paths de logs y flujo de datos
- docs/contracts/rag-security-commands.md: API completa de comandos rag-security con whitelist, patrones, claves restringidas y ejemplos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Added comprehensive JSON contract documentation** for ML Defender pipeline components, detailing configuration specifications for packet capture, detection models, firewall rules, and RAG ingestion settings.
* **Added Protobuf schema documentation (v3.1.0)** defining the network security event message hierarchy and data structures across the pipeline.
* **Added security documentation** for RAG component authorization, including command whitelist specifications and parameter safety restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->