### PR TITLE
feat(parquet): DEBT-PARQUET-SCHEMA-001 - schema Arrow v1.0 + converte…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 .PHONY: run-lab-dev kill-lab status-lab
 .PHONY: run-lab-dev-day23 kill-lab-day23 status-lab-day23
 .PHONY: kill-all check-ports restart
-.PHONY: clean clean-libs clean-components clean-all distclean test test-libs test-components test-all dev-setup schema-update
+.PHONY: clean clean-libs clean-components clean-all distclean test test-libs test-components test-all dev-setup schema-update parquet-convert test-parquet
 .PHONY: build-unified rebuild-unified quick-fix dev-setup-unified
 .PHONY: check-libbpf verify-bpf-maps diagnose-bpf
 .PHONY: test-replay-small test-replay-neris test-replay-big test-replay-neris-x86-ebpf test-replay-neris-x86-libpcap experiment-suricata-up experiment-suricata-down experiment-suricata-run experiment-suricata-results experiment-suricata-status
@@ -1199,7 +1199,16 @@ test-components:
 	@vagrant ssh -c "cd $(RAG_BUILD_DIR) && ctest --output-on-failure" || echo "⚠️  No rag-security tests configured"
 	@echo ""
 
-test-all: test-libs test-components test-provision-1 test-invariant-seed plugin-integ-test argus-network-isolate-test
+parquet-convert:
+	@echo "📦 Installing/upgrading pyarrow..."
+	@pip3 install --upgrade pyarrow --break-system-packages --quiet 2>&1 | tail -1
+	@echo "📦 Converting CSVs to Parquet..."
+	@cd /vagrant/scripts/parquet && python3 generate_parquet.py
+
+test-parquet: parquet-convert
+	@cd /vagrant/scripts/parquet && python3 validate_roundtrip.py
+
+test-all: test-libs test-components test-provision-1 test-invariant-seed plugin-integ-test argus-network-isolate-test test-parquet
 	@echo ""
 	@echo "╔════════════════════════════════════════════════════════════╗"
 	@echo "║  ✅ ALL TESTS COMPLETE                                    ║"

--- a/scripts/parquet/generate_parquet.py
+++ b/scripts/parquet/generate_parquet.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# aRGus NDR — Generador CSV -> Parquet
+# Uso: python3 scripts/parquet/generate_parquet.py
+# Makefile: make parquet-convert
+import sys, os, csv, glob
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from schemas import (
+    schema_ml_detector, ML_DETECTOR_CLASSIFICATION, ML_DETECTOR_ACTION, SENTINEL,
+    schema_firewall, FIREWALL_ACTION,
+)
+
+ML_CSV_DIR  = "/vagrant/logs/ml-detector/events"
+
+PROTOCOL_MAP = {"TCP": 6, "UDP": 17, "ICMP": 1, "OTHER": 255}
+FW_CSV_PATH = "/vagrant/logs/firewall_logs/firewall_blocks.csv"
+OUT_DIR     = "/vagrant/logs/parquet"
+
+os.makedirs(f"{OUT_DIR}/ml-detector", exist_ok=True)
+os.makedirs(f"{OUT_DIR}/firewall",    exist_ok=True)
+
+def convert_ml_day(csv_path):
+    date = os.path.basename(csv_path).replace(".csv", "")
+    out  = f"{OUT_DIR}/ml-detector/{date}.parquet"
+    rows = {f.name: [] for f in schema_ml_detector}
+
+    with open(csv_path) as f:
+        for cols in csv.reader(f):
+            if len(cols) < 127:
+                continue
+            rows["timestamp_utc_ns"].append(int(cols[0]))
+            rows["flow_id"].append(cols[1])
+            rows["anon_src_host_id"].append(cols[2] if cols[2] else None)
+            rows["anon_dst_host_id"].append(cols[3] if cols[3] else None)
+            rows["src_port"].append(int(cols[4])  if cols[4]  else None)
+            rows["dst_port"].append(int(cols[5])  if cols[5]  else None)
+            rows["protocol"].append(PROTOCOL_MAP.get(cols[6], int(cols[6]) if cols[6].isdigit() else None))
+            rows["classification"].append(ML_DETECTOR_CLASSIFICATION.get(cols[7], -1))
+            rows["confidence"].append(float(cols[8])  if cols[8]  else None)
+            rows["threat_label"].append(cols[9]   if cols[9]  else None)
+            rows["threat_score"].append(float(cols[10]) if cols[10] else None)
+            v_a = float(cols[11]) if cols[11] else None
+            v_b = float(cols[12]) if cols[12] else None
+            rows["score_a"].append(None if v_a == SENTINEL else v_a)
+            rows["score_b"].append(None if v_b == SENTINEL else v_b)
+            rows["action"].append(ML_DETECTOR_ACTION.get(cols[13], -1))
+            rows["ed25519_sig"].append(cols[-1])
+
+    table = pa.table(rows, schema=schema_ml_detector)
+    pq.write_table(table, out, compression="snappy")
+    csv_b = os.path.getsize(csv_path)
+    pq_b  = os.path.getsize(out)
+    return date, table.num_rows, csv_b, pq_b
+
+def convert_firewall():
+    out  = f"{OUT_DIR}/firewall/firewall_blocks.parquet"
+    rows = {f.name: [] for f in schema_firewall}
+
+    with open(FW_CSV_PATH) as f:
+        for cols in csv.reader(f):
+            if len(cols) < 7:
+                continue
+            rows["timestamp_utc_ns"].append(int(cols[0]) * 1_000_000)
+            rows["anon_src_host_id"].append(cols[1])
+            rows["anon_dst_host_id"].append(cols[2])
+            rows["threat_label"].append(cols[3])
+            rows["action"].append(FIREWALL_ACTION.get(cols[4], -1))
+            rows["confidence"].append(float(cols[5]))
+            rows["ed25519_sig"].append(cols[6])
+
+    table = pa.table(rows, schema=schema_firewall)
+    pq.write_table(table, out, compression="snappy")
+    return table.num_rows, os.path.getsize(FW_CSV_PATH), os.path.getsize(out)
+
+print()
+print("╔══════════════════════════════════════════════════════════╗")
+print("║  aRGus NDR — Parquet Converter                          ║")
+print("╚══════════════════════════════════════════════════════════╝")
+
+total_rows = 0
+for csv_path in sorted(glob.glob(f"{ML_CSV_DIR}/*.csv")):
+    date, n, csv_b, pq_b = convert_ml_day(csv_path)
+    ratio = csv_b / pq_b if pq_b else 0
+    marker = "  (empty CSV)" if n == 0 else ""
+    print(f"  ml-detector {date}: {n:>6} rows  {csv_b:>9,}->{pq_b:>8,} bytes  {ratio:.1f}x{marker}")
+    total_rows += n
+
+fw_rows, fw_csv_b, fw_pq_b = convert_firewall()
+fw_ratio = fw_csv_b / fw_pq_b if fw_pq_b else 0
+print(f"  firewall    (all):  {fw_rows:>6} rows  {fw_csv_b:>9,}->{fw_pq_b:>8,} bytes  {fw_ratio:.1f}x")
+print()
+print(f"  TOTAL ml-detector rows: {total_rows:,}")
+print(f"  Output: {OUT_DIR}")
+print("  ✅ DONE")
+print()

--- a/scripts/parquet/schemas/__init__.py
+++ b/scripts/parquet/schemas/__init__.py
@@ -1,0 +1,2 @@
+from .ml_detector import schema_ml_detector, ML_DETECTOR_CLASSIFICATION, ML_DETECTOR_ACTION, SENTINEL
+from .firewall import schema_firewall, FIREWALL_ACTION

--- a/scripts/parquet/schemas/firewall.py
+++ b/scripts/parquet/schemas/firewall.py
@@ -1,0 +1,25 @@
+# aRGus NDR -- Schema Arrow: firewall_acl_events
+# SECRETO INDUSTRIAL -- no exponer en docs/ publicos
+# Consejo DAY 148: 8/8 aprobado. Tipos acordados.
+# DEBT-PARQUET-TIMESTAMP-NS-001: firewall-acl-agent produce ms.
+# Workaround: writer multiplica x 1_000_000 -> ns en Parquet.
+# Fix correcto: modificar firewall-acl-agent para emitir ns en origen.
+# Revisar rag-security si en algun momento consume Parquet directamente.
+import pyarrow as pa
+
+FIREWALL_ACTION = {"ALLOW": 0, "BLOCKED": 1}
+
+schema_firewall = pa.schema([
+    pa.field("timestamp_utc_ns", pa.int64(),
+             metadata={b"note": b"epoch ns UTC - fuente CSV en ms, x1_000_000 en ingesta"}),
+    pa.field("anon_src_host_id", pa.dictionary(pa.int32(), pa.utf8()),
+             metadata={b"note": b"HMAC-SHA256(K_pseudo) - IP en claro en test"}),
+    pa.field("anon_dst_host_id", pa.dictionary(pa.int32(), pa.utf8()),
+             metadata={b"note": b"HMAC-SHA256(K_pseudo) - IP en claro en test"}),
+    pa.field("threat_label",     pa.dictionary(pa.int32(), pa.utf8())),
+    pa.field("action",           pa.int8(),
+             metadata={b"encoding": b"0=ALLOW 1=BLOCKED"}),
+    pa.field("confidence",       pa.float32()),
+    pa.field("ed25519_sig",      pa.utf8(),
+             metadata={b"note": b"Ed25519 hex 64 chars"}),
+])

--- a/scripts/parquet/schemas/ml_detector.py
+++ b/scripts/parquet/schemas/ml_detector.py
@@ -1,0 +1,32 @@
+# aRGus NDR -- Schema Arrow: ml_detector_events
+# SECRETO INDUSTRIAL -- no exponer en docs/ publicos
+# Consejo DAY 148: 8/8 aprobado. Tipos acordados.
+import pyarrow as pa
+
+ML_DETECTOR_CLASSIFICATION = {"BENIGN": 0, "MALICIOUS": 1}
+ML_DETECTOR_ACTION         = {"ALLOW": 0, "DROP": 1, "BLOCK": 2}
+SENTINEL = -9999.0  # valores CIC-IDS-2017 ausentes -> null en Parquet
+
+schema_ml_detector = pa.schema([
+    pa.field("timestamp_utc_ns", pa.int64(),
+             metadata={b"note": b"epoch nanoseconds UTC"}),
+    pa.field("flow_id",          pa.dictionary(pa.int32(), pa.utf8())),
+    pa.field("anon_src_host_id", pa.dictionary(pa.int32(), pa.utf8()),
+             metadata={b"note": b"HMAC-SHA256(K_pseudo) - vacio en test"}),
+    pa.field("anon_dst_host_id", pa.dictionary(pa.int32(), pa.utf8()),
+             metadata={b"note": b"HMAC-SHA256(K_pseudo) - vacio en test"}),
+    pa.field("src_port",         pa.uint16()),
+    pa.field("dst_port",         pa.uint16()),
+    pa.field("protocol",         pa.int8()),
+    pa.field("classification",   pa.int8(),
+             metadata={b"encoding": b"0=BENIGN 1=MALICIOUS"}),
+    pa.field("confidence",       pa.float32()),
+    pa.field("threat_label",     pa.dictionary(pa.int32(), pa.utf8())),
+    pa.field("threat_score",     pa.float32()),
+    pa.field("score_a",          pa.float32()),
+    pa.field("score_b",          pa.float32()),
+    pa.field("action",           pa.int8(),
+             metadata={b"encoding": b"0=ALLOW 1=DROP 2=BLOCK"}),
+    pa.field("ed25519_sig",      pa.utf8(),
+             metadata={b"note": b"Ed25519 hex 64 chars"}),
+])

--- a/scripts/parquet/validate_roundtrip.py
+++ b/scripts/parquet/validate_roundtrip.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# aRGus NDR — Validacion roundtrip Parquet
+# Uso: python3 scripts/parquet/validate_roundtrip.py
+# Makefile: make test-parquet (depende de parquet-convert)
+import sys, os, glob
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import pyarrow.parquet as pq
+from schemas import schema_ml_detector, schema_firewall
+
+OUT_DIR = "/vagrant/logs/parquet"
+errors  = 0
+
+def check(condition, msg):
+    global errors
+    if not condition:
+        print(f"  FAIL: {msg}")
+        errors += 1
+
+ml_files = sorted(glob.glob(f"{OUT_DIR}/ml-detector/*.parquet"))
+check(len(ml_files) > 0, "No Parquet files found in ml-detector/")
+
+for path in ml_files:
+    t = pq.read_table(path)
+    check(t.schema.equals(schema_ml_detector),
+          f"{os.path.basename(path)}: schema mismatch")
+    if t.num_rows == 0:
+        print(f"  SKIP: {os.path.basename(path)} empty table (CSV vacio)")
+        continue
+    ts = t["timestamp_utc_ns"][0].as_py()
+    check(ts > 1_700_000_000_000_000_000,
+          f"{os.path.basename(path)}: timestamp out of range ({ts})")
+
+fw_path = f"{OUT_DIR}/firewall/firewall_blocks.parquet"
+check(os.path.exists(fw_path), "firewall_blocks.parquet not found")
+if os.path.exists(fw_path):
+    t = pq.read_table(fw_path)
+    check(t.schema.equals(schema_firewall), "firewall: schema mismatch")
+    check(t.num_rows > 0, "firewall: empty table")
+    ts = t["timestamp_utc_ns"][0].as_py()
+    check(ts > 1_700_000_000_000_000_000,
+          f"firewall: timestamp out of range ({ts})")
+    check(ts % 1_000_000 == 0,
+          f"firewall: timestamp no es multiplo de 1_000_000 (ms->ns fallida)")
+
+print()
+print("╔══════════════════════════════════════════════════════════╗")
+print("║  aRGus NDR — Parquet Roundtrip Validation               ║")
+print("╚══════════════════════════════════════════════════════════╝")
+print(f"  ml-detector files validados: {len(ml_files)}")
+print(f"  firewall files validados:    1")
+if errors == 0:
+    print("  ROUNDTRIP PASSED")
+else:
+    print(f"  {errors} ASSERTION(S) FAILED")
+    sys.exit(1)
+print()


### PR DESCRIPTION
…r + roundtrip validation

- scripts/parquet/schemas/ml_detector.py: schema Arrow ml_detector_events (15 fields)
- scripts/parquet/schemas/firewall.py: schema Arrow firewall_acl_events (7 fields)
- scripts/parquet/generate_parquet.py: CSV->Parquet converter, Snappy, por dia
- scripts/parquet/validate_roundtrip.py: roundtrip assertions (schema + timestamp + ms->ns)
- Makefile: parquet-convert + test-parquet como dependencia de test-all
- Tipos acordados Consejo DAY 148 8/8: int64 ts, float32 scores, dict utf8 IDs, int8 enums
- DEBT-PARQUET-TIMESTAMP-NS-001 registrada: firewall ms->ns workaround en writer
- Ratio compresion real: 11-12x ml-detector (207,122 rows / 53 dias), 1.5x firewall
- PROTOCOL_MAP: TCP=6 UDP=17 ICMP=1 OTHER=255

ROUNDTRIP: 53 ml-detector + 1 firewall PASSED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Parquet data format support with conversion tools and automated data management capabilities.

* **Testing**
  * Extended the test suite with new automated Parquet conversion and roundtrip validation testing to ensure data integrity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alonsoir/argus/pull/62)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->