### PR TITLE
feat(provision): DEBT-VAULT-PROVISION-PROD-001 — Vault/Ansible/Jinja2/Jenkins

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -582,6 +582,36 @@ BASHRC_EOF
       sha256sum /vagrant/dist/vendor/falco_*.deb > /vagrant/dist/vendor/CHECKSUMS
       echo "✅ dist/vendor/CHECKSUMS actualizado"
 
+
+      # ── Ansible + Jinja2 (DEBT-VAULT-PROVISION-PROD-001) ─────────────────
+      # Ansible: controller de orquestacion (solo en dev, no en prod — ADR-039)
+      if ! command -v ansible &>/dev/null; then
+        echo "📦 Instalando Ansible + Jinja2..."
+        apt-get install -y ansible
+        pip3 install jinja2 --break-system-packages --quiet
+        echo "✅ Ansible $(ansible --version | head -1) instalado"
+        echo "✅ Jinja2 $(python3 -c 'import jinja2; print(jinja2.__version__)')"
+      else
+        echo "✅ Ansible ya instalado: $(ansible --version | head -1)"
+      fi
+
+      # ── Jenkins (DEBT-VAULT-PROVISION-PROD-001) ───────────────────────────
+      # CI/CD controller — solo en dev/central, no en nodos edge (ADR-039)
+      if ! command -v jenkins &>/dev/null && [ ! -f /etc/init.d/jenkins ]; then
+        echo "📦 Instalando Jenkins..."
+        apt-get install -y default-jdk-headless 2>&1 | tail -2
+        wget -O /usr/share/keyrings/jenkins-keyring.asc \
+          https://pkg.jenkins.io/debian-stable/jenkins.io-2023.key 2>/dev/null
+        echo "deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] https://pkg.jenkins.io/debian-stable binary/" | \
+          tee /etc/apt/sources.list.d/jenkins.list
+        apt-get update -qq
+        apt-get install -y jenkins
+        systemctl enable jenkins
+        echo "✅ Jenkins instalado (puerto 8080)"
+        echo "⚠️  Primer arranque requiere: sudo cat /var/lib/jenkins/secrets/initialAdminPassword"
+      else
+        echo "✅ Jenkins ya instalado"
+      fi
       # ── HashiCorp Vault (DEBT-CRYPTO-MATERIAL-STORAGE-001) ─────────────────
       if ! command -v vault &>/dev/null; then
         echo "📦 Instalando HashiCorp Vault..."

--- a/vagrant/hardened-arm64/Vagrantfile
+++ b/vagrant/hardened-arm64/Vagrantfile
@@ -129,6 +129,24 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     chown -R ml-defender:ml-defender /etc/ml-defender /var/log/ml-defender \
                                      /usr/lib/ml-defender
 
+
+    # ── HashiCorp Vault (DEBT-VAULT-PROVISION-PROD-001) ──────────────────────
+    # Runtime binary only — no dev tools, BSR axiom respected (ADR-039)
+    if ! command -v vault &>/dev/null; then
+      echo "=== Installing HashiCorp Vault ==="
+      apt-get install -y gnupg wget
+      wget -O - https://apt.releases.hashicorp.com/gpg 2>/dev/null | \
+        gpg --dearmor | \
+        tee /usr/share/keyrings/hashicorp-archive-keyring.gpg > /dev/null
+      echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com bookworm main" | \
+        tee /etc/apt/sources.list.d/hashicorp.list
+      apt-get update -qq
+      apt-get install -y vault
+      echo "OK: Vault $(vault version | head -1) instalado"
+    else
+      echo "OK: Vault ya instalado: $(vault version | head -1)"
+    fi
+
     echo "=== Provisioning complete ==="
     echo "Next steps:"
     echo "  1. Copy binaries from dist/ to /usr/local/bin/"

--- a/vagrant/hardened-x86/Vagrantfile
+++ b/vagrant/hardened-x86/Vagrantfile
@@ -125,6 +125,24 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     chown -R ml-defender:ml-defender /etc/ml-defender /var/log/ml-defender \
                                      /usr/lib/ml-defender
 
+
+    # ── HashiCorp Vault (DEBT-VAULT-PROVISION-PROD-001) ──────────────────────
+    # Runtime binary only — no dev tools, BSR axiom respected (ADR-039)
+    if ! command -v vault &>/dev/null; then
+      echo "=== Installing HashiCorp Vault ==="
+      apt-get install -y gnupg wget
+      wget -O - https://apt.releases.hashicorp.com/gpg 2>/dev/null | \
+        gpg --dearmor | \
+        tee /usr/share/keyrings/hashicorp-archive-keyring.gpg > /dev/null
+      echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com bookworm main" | \
+        tee /etc/apt/sources.list.d/hashicorp.list
+      apt-get update -qq
+      apt-get install -y vault
+      echo "OK: Vault $(vault version | head -1) instalado"
+    else
+      echo "OK: Vault ya instalado: $(vault version | head -1)"
+    fi
+
     echo "=== Provisioning complete ==="
     echo "Next steps:"
     echo "  1. Copy binaries from dist/ to /usr/local/bin/"


### PR DESCRIPTION
## Distribucion por entorno

| Herramienta | Dev | Prod hardened | Razon |
|---|---|---|---|
| Vault | ya existia | añadido | K_pseudo en ambos |
| Ansible | añadido | NO | controller, no target (ADR-039) |
| Jinja2 | añadido | NO | templating para Ansible |
| Jenkins | añadido | NO | CI/CD central, no edge |

## ADR-039 BSR axiom
Prod hardened solo recibe el binario Vault runtime. Sin compiler, sin toolchain.
BSR check sigue pasando.

## Siguiente
Playbooks Ansible para despliegue de binarios dev→prod.