### PR TITLE
feat(ansible): Jinja2 templates + playbook deploy_configs

### DIFF
--- a/ansible/group_vars/dev.yml
+++ b/ansible/group_vars/dev.yml
@@ -1,0 +1,37 @@
+# aRGus NDR -- group_vars dev
+# Ambiente: Vagrant/VirtualBox, dev, x86-64
+
+argus_env: dev
+argus_config_base: /vagrant
+
+# Sniffer
+sniffer_profile: dual_nic
+sniffer_host_interface: eth1
+sniffer_gateway_interface: eth2
+sniffer_log_file: /vagrant/logs/lab/sniffer.log
+sniffer_zmq_output_address: "127.0.0.1"
+sniffer_zmq_output_port: 5571
+
+# ML Detector
+ml_profile: lab
+ml_log_file: /vagrant/logs/lab/detector.log
+ml_csv_base_dir: /vagrant/logs/ml-detector/events
+ml_rag_base_dir: /vagrant/logs/rag
+ml_models_base_dir: models/production
+ml_zmq_input: "tcp://127.0.0.1:5571"
+ml_zmq_output: "tcp://0.0.0.0:5572"
+ml_worker_threads: 2
+
+# RAG Logger
+rag_base_path: /vagrant/logs/rag
+rag_deployment_id: ml-defender-dev-001
+rag_node_id: defender-node-dev-01
+
+# etcd
+etcd_endpoints:
+  - "localhost:2379"
+
+# Vault
+vault_addr: "http://127.0.0.1:8200"
+vault_token: "argus-dev-token"
+vault_k_pseudo_path: "argus/k_pseudo"

--- a/ansible/group_vars/prod.yml
+++ b/ansible/group_vars/prod.yml
@@ -1,0 +1,37 @@
+# aRGus NDR -- group_vars prod
+# Ambiente: bare-metal / hardened VM, produccion
+
+argus_env: prod
+argus_config_base: /etc/ml-defender
+
+# Sniffer
+sniffer_profile: bare_metal
+sniffer_host_interface: eth0
+sniffer_gateway_interface: eth1
+sniffer_log_file: /var/log/ml-defender/sniffer.log
+sniffer_zmq_output_address: "127.0.0.1"
+sniffer_zmq_output_port: 5571
+
+# ML Detector
+ml_profile: bare_metal
+ml_log_file: /var/log/ml-defender/detector.log
+ml_csv_base_dir: /var/log/ml-defender/ml-detector/events
+ml_rag_base_dir: /var/log/ml-defender/rag
+ml_models_base_dir: /usr/lib/ml-defender/models/production
+ml_zmq_input: "tcp://127.0.0.1:5571"
+ml_zmq_output: "tcp://0.0.0.0:5572"
+ml_worker_threads: 8
+
+# RAG Logger
+rag_base_path: /var/log/ml-defender/rag
+rag_deployment_id: "ml-defender-prod-{{ inventory_hostname }}"
+rag_node_id: "{{ inventory_hostname }}"
+
+# etcd
+etcd_endpoints:
+  - "localhost:2379"
+
+# Vault
+vault_addr: "http://127.0.0.1:8200"
+vault_token: "{{ vault_token_secret }}"  # inyectado por Jenkins, nunca en repo
+vault_k_pseudo_path: "argus/k_pseudo"

--- a/ansible/inventory/dev.yml
+++ b/ansible/inventory/dev.yml
@@ -1,0 +1,9 @@
+all:
+  children:
+    argus_dev:
+      hosts:
+        defender:
+          ansible_host: 192.168.56.20
+          ansible_user: vagrant
+          ansible_ssh_private_key_file: .vagrant/machines/defender/virtualbox/private_key
+          ansible_ssh_common_args: "-o StrictHostKeyChecking=no"

--- a/ansible/inventory/prod.yml
+++ b/ansible/inventory/prod.yml
@@ -1,0 +1,9 @@
+all:
+  children:
+    argus_prod:
+      hosts:
+        argus-node-01:
+          ansible_host: "{{ prod_host }}"
+          ansible_user: ml-defender
+          ansible_ssh_private_key_file: "{{ prod_ssh_key }}"
+          ansible_ssh_common_args: "-o StrictHostKeyChecking=no"

--- a/ansible/playbooks/deploy_configs.yml
+++ b/ansible/playbooks/deploy_configs.yml
@@ -1,0 +1,75 @@
+---
+# aRGus NDR -- Playbook: deploy component configs
+# Uso dev:  ansible-playbook -i ansible/inventory/dev.yml ansible/playbooks/deploy_configs.yml
+# Uso prod: ansible-playbook -i ansible/inventory/prod.yml ansible/playbooks/deploy_configs.yml
+#           -e vault_token_secret=<token>
+#
+# Requiere: ansible, jinja2
+# Jenkins: stage Deploy Configs llama este playbook con el inventario correcto
+
+- name: Deploy aRGus NDR component configurations
+  hosts: all
+  become: true
+  gather_facts: true
+
+  vars:
+    config_dest_sniffer:    "{{ argus_config_base }}/sniffer/config/sniffer.json"
+    config_dest_ml:         "{{ argus_config_base }}/ml-detector/config/ml_detector_config.json"
+    config_dest_rag_logger: "{{ argus_config_base }}/ml-detector/config/rag_logger_config.json"
+
+  tasks:
+
+    - name: "Ensure config directories exist"
+      file:
+        path: "{{ item }}"
+        state: directory
+        mode: "0750"
+      loop:
+        - "{{ argus_config_base }}/sniffer/config"
+        - "{{ argus_config_base }}/ml-detector/config"
+
+    - name: "Deploy sniffer.json"
+      template:
+        src: "../templates/sniffer.json.j2"
+        dest: "{{ config_dest_sniffer }}"
+        mode: "0640"
+      notify: restart sniffer
+
+    - name: "Deploy ml_detector_config.json"
+      template:
+        src: "../templates/ml_detector_config.json.j2"
+        dest: "{{ config_dest_ml }}"
+        mode: "0640"
+      notify: restart ml-detector
+
+    - name: "Deploy rag_logger_config.json"
+      template:
+        src: "../templates/rag_logger_config.json.j2"
+        dest: "{{ config_dest_rag_logger }}"
+        mode: "0640"
+      notify: restart ml-detector
+
+    - name: "Verify generated JSON is valid"
+      command: "python3 -m json.tool {{ item }}"
+      loop:
+        - "{{ config_dest_sniffer }}"
+        - "{{ config_dest_ml }}"
+        - "{{ config_dest_rag_logger }}"
+      changed_when: false
+
+    - name: "Report deployed configs"
+      debug:
+        msg: "Config desplegada en {{ item }}"
+      loop:
+        - "{{ config_dest_sniffer }}"
+        - "{{ config_dest_ml }}"
+        - "{{ config_dest_rag_logger }}"
+
+  handlers:
+    - name: restart sniffer
+      debug:
+        msg: "TODO: make pipeline-stop && make pipeline-start (FEAT-SYSTEMD-001)"
+
+    - name: restart ml-detector
+      debug:
+        msg: "TODO: make pipeline-stop && make pipeline-start (FEAT-SYSTEMD-001)"

--- a/ansible/templates/ml_detector_config.json.j2
+++ b/ansible/templates/ml_detector_config.json.j2
@@ -1,0 +1,72 @@
+{
+  "_header": "aRGus NDR -- ml-detector config -- generado por Ansible/Jinja2",
+  "_env": "{{ argus_env }}",
+  "_generated": "{{ ansible_date_time.iso8601 | default('unknown') }}",
+  "component": {
+    "name": "cpp_ml_detector_tricapa",
+    "version": "1.0.0",
+    "mode": "ml_inference_tricapa"
+  },
+  "profile": "{{ ml_profile }}",
+  "network": {
+    "input_socket": {
+      "endpoint": "{{ ml_zmq_input }}",
+      "mode": "connect",
+      "socket_type": "PULL",
+      "high_water_mark": 1000
+    },
+    "output_socket": {
+      "endpoint": "{{ ml_zmq_output }}",
+      "mode": "bind",
+      "socket_type": "PUB",
+      "high_water_mark": 1000
+    }
+  },
+  "etcd": {
+    "enabled": true,
+    "endpoints": {{ etcd_endpoints | to_json }},
+    "connection_timeout_ms": 5000,
+    "retry_attempts": 3,
+    "retry_interval_ms": 1000,
+    "crypto_token_path": "/crypto/ml-detector/tokens",
+    "config_sync_path": "/config/ml-detector",
+    "required_for_encryption": false,
+    "fallback_mode": "standalone_compression_only"
+  },
+  "threading": {
+    "worker_threads": {{ ml_worker_threads }},
+    "total_worker_threads": 7
+  },
+  "ml": {
+    "models_base_dir": "{{ ml_models_base_dir }}"
+  },
+  "logging": {
+    "level": "INFO",
+    "file": "{{ ml_log_file }}",
+    "max_file_size_mb": 200,
+    "backup_count": 10
+  },
+  "csv_writer": {
+    "base_dir": "{{ ml_csv_base_dir }}",
+    "min_score_threshold": 0.5,
+    "max_events_per_file": 10000
+  },
+  "rag_logger": {
+    "enabled": true,
+    "base_dir": "{{ ml_rag_base_dir }}",
+    "log_detections_only": true,
+    "min_score_threshold": 0.5
+  },
+  "identity": {
+    "component_id": "ml-detector",
+    "keys_dir": "/etc/ml-defender/ml-detector",
+    "public_key": "/etc/ml-defender/ml-detector/public.pem",
+    "private_key": "/etc/ml-defender/ml-detector/private.pem",
+    "seed_bin": "/etc/ml-defender/ml-detector/seed.bin"
+  },
+  "plugins": {
+    "directory": "/usr/lib/ml-defender/plugins",
+    "budget_us": 100,
+    "enabled": []
+  }
+}

--- a/ansible/templates/rag_logger_config.json.j2
+++ b/ansible/templates/rag_logger_config.json.j2
@@ -1,0 +1,26 @@
+{
+  "_header": "aRGus NDR -- rag-logger config -- generado por Ansible/Jinja2",
+  "_env": "{{ argus_env }}",
+  "_generated": "{{ ansible_date_time.iso8601 | default('unknown') }}",
+  "base_path": "{{ rag_base_path }}",
+  "deployment_id": "{{ rag_deployment_id }}",
+  "node_id": "{{ rag_node_id }}",
+  "log_version": "1.0",
+  "thresholds": {
+    "min_score_to_log": 0.70,
+    "min_divergence_to_log": 0.30,
+    "log_all_divergences": true,
+    "log_consensus": false
+  },
+  "performance": {
+    "max_events_per_file": 10000,
+    "max_file_size_mb": 100,
+    "save_protobuf_artifacts": true,
+    "save_json_artifacts": true,
+    "compress_on_rotate": false
+  },
+  "features": {
+    "enable_geoip": false,
+    "enable_pcap_capture": false
+  }
+}

--- a/ansible/templates/sniffer.json.j2
+++ b/ansible/templates/sniffer.json.j2
@@ -1,0 +1,67 @@
+{
+  "_header": "aRGus NDR -- sniffer config -- generado por Ansible/Jinja2",
+  "_env": "{{ argus_env }}",
+  "_generated": "{{ ansible_date_time.iso8601 | default('unknown') }}",
+  "component": {
+    "name": "cpp_evolutionary_sniffer",
+    "version": "3.3.3",
+    "mode": "kernel_user_hybrid",
+    "kernel_version_required": "6.1.0"
+  },
+  "deployment": {
+    "mode": "dual",
+    "host_interface": {
+      "name": "{{ sniffer_host_interface }}",
+      "role": "wan",
+      "mode": "host-based",
+      "xdp_mode": "native",
+      "promiscuous": true,
+      "capture_direction": "ingress_only"
+    },
+    "gateway_interface": {
+      "name": "{{ sniffer_gateway_interface }}",
+      "role": "lan",
+      "mode": "gateway",
+      "xdp_mode": "native",
+      "promiscuous": true,
+      "capture_direction": "bidirectional"
+    }
+  },
+  "profile": "{{ sniffer_profile }}",
+  "network": {
+    "output_socket": {
+      "address": "{{ sniffer_zmq_output_address }}",
+      "port": {{ sniffer_zmq_output_port }},
+      "mode": "bind",
+      "socket_type": "PUSH",
+      "high_water_mark": 1000
+    }
+  },
+  "etcd": {
+    "enabled": true,
+    "endpoints": {{ etcd_endpoints | to_json }},
+    "connection_timeout_ms": 5000,
+    "retry_attempts": 3,
+    "retry_interval_ms": 1000,
+    "crypto_token_path": "/crypto/sniffer/tokens",
+    "config_sync_path": "/config/sniffer",
+    "required_for_encryption": true,
+    "fallback_mode": "standalone_unencrypted"
+  },
+  "logging": {
+    "level": "INFO",
+    "file": "{{ sniffer_log_file }}",
+    "max_file_size_mb": 200,
+    "backup_count": 10
+  },
+  "identity": {
+    "component_id": "sniffer",
+    "keys_dir": "/etc/ml-defender/sniffer",
+    "public_key": "/etc/ml-defender/sniffer/public.pem",
+    "private_key": "/etc/ml-defender/sniffer/private.pem",
+    "seed_bin": "/etc/ml-defender/sniffer/seed.bin"
+  },
+  "plugins": {
+    "enabled": []
+  }
+}


### PR DESCRIPTION
## Qué
- Estructura Ansible completa: inventory, group_vars, templates, playbook
- 3 templates Jinja2: sniffer.json, ml_detector_config.json, rag_logger_config.json
- Variables separadas por ambiente: dev (Vagrant) y prod (bare-metal)
- Playbook deploy_configs.yml con validación JSON post-render

## Validado
- YAML syntax: 5/5 OK
- Jinja2 render dev: 3/3 OK

## Siguiente
- Integrar en Jenkinsfile como stage 'Deploy Configs'
- Añadir firewall-acl-agent y etcd-server templates