### PR TITLE
feat(day168): Suricata/Zeek/Wazuh multi-VM + community_id (ADR-048 F2-F4)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -980,8 +980,6 @@ BASHRC_EOF
 
 # ════════════════════════════════════════════════════════════════════════════
   # SURICATA VM — IDS signatures (ADR-048 F2)
-  # autostart: false — arrancar con: vagrant up suricata
-  # community_id: yes — primary key para join cross-tool
   # ════════════════════════════════════════════════════════════════════════════
   config.vm.define "suricata", autostart: false do |suricata|
     suricata.vm.box         = "debian/bookworm64"
@@ -1000,8 +998,6 @@ BASHRC_EOF
       vb.customize ["modifyvm", :id, "--usb", "off"]
     end
 
-    # eth0: NAT (Vagrant management)
-    # eth1: 192.168.100.10 — argus experiment LAN (mismo intnet que defender eth2)
     suricata.vm.network "private_network",
       ip: "192.168.100.10",
       virtualbox__intnet: "ml_defender_gateway_lan"
@@ -1010,56 +1006,53 @@ BASHRC_EOF
       mount_options: ["dmode=775,fmode=775,exec"]
 
     suricata.vm.provision "shell", name: "install-suricata", inline: <<-SHELL
-      set -e
       export DEBIAN_FRONTEND=noninteractive
       echo "=== Installing Suricata + ET Open rules (ADR-048 F2) ==="
 
       apt-get update -qq
-      apt-get install -y suricata suricata-update \
-        tcpreplay net-tools curl jq python3 procps chrony
+      apt-get install -y curl gnupg2 chrony net-tools procps python3 jq tcpreplay
 
-      suricata --build-info | grep "^Version"
-
-      # NTP sync — community_id requiere timestamps coherentes (ADR-046 P0)
       systemctl enable chrony
       systemctl start chrony
       chronyc makestep 1.0 3 2>/dev/null || true
 
-      # Reglas ET Open
-      suricata-update --no-reload
+      # DNS fix DESPUES de chrony — chattr bloquea sobreescritura
+      echo "nameserver 8.8.8.8" > /etc/resolv.conf
+      echo "nameserver 1.1.1.1" >> /etc/resolv.conf
+      chattr +i /etc/resolv.conf
+
+      # bookworm-backports para libhtp2 >= 0.5.50 (Suricata 7.x)
+      echo "deb http://deb.debian.org/debian bookworm-backports main" \
+        > /etc/apt/sources.list.d/backports.list
+      apt-get update -qq
+      apt-get install -y -t bookworm-backports libhtp2 || { echo "❌ libhtp2 failed"; exit 1; }
+      apt-get install -y suricata suricata-update || { echo "❌ suricata install failed"; exit 1; }
+
+      suricata --build-info | grep -i "version" || true
+
+      suricata-update --no-reload || true
       echo "Rules: $(find /var/lib/suricata/rules -name '*.rules' 2>/dev/null | head -1)"
 
-      # Interfaz: eth1 es la intnet compartida con defender
       sed -i 's/- interface: eth0/- interface: eth1/' /etc/suricata/suricata.yaml
       ip link set eth1 promisc on || true
       echo 'ip link set eth1 promisc on' >> /etc/rc.local
       chmod +x /etc/rc.local
 
-      # community-id: yes — primary key para join con Zeek/aRGus (DEBT-ARGUSPP-COMMUNITY-ID-001)
-      if grep -q "community-id: false" /etc/suricata/suricata.yaml; then
-        sed -i 's/community-id: false/community-id: yes/' /etc/suricata/suricata.yaml
-      else
-        sed -i '/eve-log:/a\      community-id: yes' /etc/suricata/suricata.yaml
-      fi
+      # community-id: yes — DEBT-ARGUSPP-COMMUNITY-ID-001
+      sed -i '/community-id:/s/false/yes/' /etc/suricata/suricata.yaml
 
-      # eve.json accesible desde correlation-engine
       mkdir -p /var/log/suricata
       chown -R suricata:suricata /var/log/suricata 2>/dev/null || true
 
-      # Verificar community-id en config
-      grep "community-id" /etc/suricata/suricata.yaml || \
-        echo "⚠️  community-id no encontrado en suricata.yaml"
-
       echo "=== Suricata ready ==="
-      suricata --build-info | grep -E "Version|AF_PACKET|PCAP"
+      suricata --build-info | grep -iE "version|AF_PACKET|PCAP" || true
       echo "community-id: $(grep 'community-id' /etc/suricata/suricata.yaml | head -1)"
+      ip link show eth1 | grep -i promisc || echo "⚠️  eth1 promisc no activo aun"
     SHELL
   end  # End suricata VM
 
   # ════════════════════════════════════════════════════════════════════════════
   # ZEEK VM — protocol analysis / observability layer (ADR-048 F3)
-  # autostart: false — arrancar con: vagrant up zeek
-  # community_id: obligatorio — mismo primary key que Suricata
   # ════════════════════════════════════════════════════════════════════════════
   config.vm.define "zeek", autostart: false do |zeek|
     zeek.vm.box         = "debian/bookworm64"
@@ -1078,7 +1071,6 @@ BASHRC_EOF
       vb.customize ["modifyvm", :id, "--usb", "off"]
     end
 
-    # eth1: 192.168.100.11 — argus experiment LAN
     zeek.vm.network "private_network",
       ip: "192.168.100.11",
       virtualbox__intnet: "ml_defender_gateway_lan"
@@ -1087,58 +1079,58 @@ BASHRC_EOF
       mount_options: ["dmode=775,fmode=775,exec"]
 
     zeek.vm.provision "shell", name: "install-zeek", inline: <<-SHELL
-      set -e
       export DEBIAN_FRONTEND=noninteractive
       echo "=== Installing Zeek (ADR-048 F3) ==="
 
       apt-get update -qq
       apt-get install -y curl gnupg2 chrony net-tools procps
 
-      # NTP sync
       systemctl enable chrony
       systemctl start chrony
       chronyc makestep 1.0 3 2>/dev/null || true
 
-      # Zeek repo oficial
+      # DNS fix DESPUES de chrony
+      echo "nameserver 8.8.8.8" > /etc/resolv.conf
+      echo "nameserver 1.1.1.1" >> /etc/resolv.conf
+      chattr +i /etc/resolv.conf
+
+      # Zeek repo oficial OpenSUSE
       echo 'deb http://download.opensuse.org/repositories/security:/zeek/Debian_12/ /' \
         > /etc/apt/sources.list.d/zeek.list
       curl -fsSL https://download.opensuse.org/repositories/security:/zeek/Debian_12/Release.key \
         | gpg --dearmor > /etc/apt/trusted.gpg.d/zeek.gpg
       apt-get update -qq
-      apt-get install -y zeek
+      apt-get install -y zeek || { echo "❌ zeek install failed"; exit 1; }
 
-      # PATH
       echo 'export PATH=/opt/zeek/bin:$PATH' >> /etc/profile.d/zeek.sh
       chmod +x /etc/profile.d/zeek.sh
       export PATH=/opt/zeek/bin:$PATH
 
-      # Configurar interfaz eth1
       sed -i 's/interface=eth0/interface=eth1/' /opt/zeek/etc/node.cfg
+      ip link set eth1 promisc on || true
+      echo 'ip link set eth1 promisc on' >> /etc/rc.local
+      chmod +x /etc/rc.local
 
       # community-id — DEBT-ARGUSPP-COMMUNITY-ID-001
-      # Zeek 5.x incluye community-id nativo via policy/protocols/conn/community-id-v1.zeek
       if [ ! -f /opt/zeek/etc/local.zeek ]; then
         touch /opt/zeek/etc/local.zeek
       fi
       if ! grep -q "community-id" /opt/zeek/etc/local.zeek; then
         echo "@load policy/protocols/conn/community-id-v1" >> /opt/zeek/etc/local.zeek
-        echo "✅ community-id añadido a local.zeek"
       fi
 
-      # Logs en /var/log/zeek para acceso desde correlation-engine
       mkdir -p /var/log/zeek
       ln -sf /opt/zeek/logs/current /var/log/zeek/current 2>/dev/null || true
 
-      /opt/zeek/bin/zeek --version
       echo "=== Zeek ready ==="
+      /opt/zeek/bin/zeek --version || true
       echo "community-id: $(grep community-id /opt/zeek/etc/local.zeek)"
+      ip link show eth1 | grep -i promisc || echo "⚠️  eth1 promisc no activo aun"
     SHELL
   end  # End zeek VM
 
   # ════════════════════════════════════════════════════════════════════════════
   # WAZUH VM — host-based events / HIDS (ADR-048 F4)
-  # autostart: false — arrancar con: vagrant up wazuh
-  # 4096MB — Wazuh manager es Java, necesita más RAM
   # ════════════════════════════════════════════════════════════════════════════
   config.vm.define "wazuh", autostart: false do |wazuh|
     wazuh.vm.box         = "debian/bookworm64"
@@ -1156,7 +1148,6 @@ BASHRC_EOF
       vb.customize ["modifyvm", :id, "--usb", "off"]
     end
 
-    # eth1: 192.168.100.12 — argus experiment LAN
     wazuh.vm.network "private_network",
       ip: "192.168.100.12",
       virtualbox__intnet: "ml_defender_gateway_lan"
@@ -1165,37 +1156,35 @@ BASHRC_EOF
       mount_options: ["dmode=775,fmode=775,exec"]
 
     wazuh.vm.provision "shell", name: "install-wazuh", inline: <<-SHELL
-      set -e
       export DEBIAN_FRONTEND=noninteractive
       echo "=== Installing Wazuh manager (ADR-048 F4) ==="
 
       apt-get update -qq
       apt-get install -y curl gnupg2 chrony net-tools procps
 
-      # NTP sync
       systemctl enable chrony
       systemctl start chrony
       chronyc makestep 1.0 3 2>/dev/null || true
 
-      # Wazuh repo
+      # DNS fix DESPUES de chrony
+      echo "nameserver 8.8.8.8" > /etc/resolv.conf
+      echo "nameserver 1.1.1.1" >> /etc/resolv.conf
+      chattr +i /etc/resolv.conf
+
       curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH \
         | gpg --dearmor > /usr/share/keyrings/wazuh.gpg
       echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" \
         > /etc/apt/sources.list.d/wazuh.list
       apt-get update -qq
-
-      # Manager
-      # WAZUH_MANAGER_PASSWORD se inyecta desde el entorno del host
-      # export WAZUH_MANAGER_PASSWORD=<valor> antes de vagrant up wazuh
-      # En dev sin password configurado: Wazuh usa el default interno
-      apt-get install -y wazuh-manager
+      apt-get install -y wazuh-manager || { echo "❌ wazuh-manager install failed"; exit 1; }
 
       systemctl daemon-reload
       systemctl enable wazuh-manager
-      systemctl start wazuh-manager
+      systemctl start wazuh-manager || true
 
       echo "=== Wazuh manager ready ==="
-      /var/ossec/bin/wazuh-control status | head -5
+      /var/ossec/bin/wazuh-control status | head -5 || true
     SHELL
   end  # End wazuh VM
+
 end  # End Vagrant configuration

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -937,39 +937,265 @@ BASHRC_EOF
       virtualbox__intnet: "ml_defender_gateway_lan"
 
     client.vm.provision "shell", name: "client-setup", run: "always", inline: <<-CLIENT
-      export DEBIAN_FRONTEND=noninteractive
-      set -x
-      echo "═══════════════════════════════════════════════════════════════════"
-      echo "║  ML CLIENT - Traffic Generator Setup                            ║"
-      echo "═══════════════════════════════════════════════════════════════════"
+          export DEBIAN_FRONTEND=noninteractive
+          set -e
+          echo "=== ML CLIENT — Traffic Generator + MITRE Attack Tools ==="
 
-      # Install tools
-      apt-get update -qq
-      apt-get install -y --no-install-recommends \
-        --allow-downgrades --allow-remove-essential --allow-change-held-packages \
-        -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
-        curl wget hping3 nmap iproute2 \
-        tcpdump tcpreplay netcat-openbsd dnsutils \
-        iputils-ping net-tools
+          apt-get update -qq
+          apt-get install -y --no-install-recommends \
+            curl wget iproute2 net-tools dnsutils \
+            tcpdump tcpreplay netcat-openbsd \
+            iputils-ping procps chrony \
+            nmap hydra sqlmap \
+            metasploit-framework \
+            python3 python3-pip git
 
-      # Install iperf3 separately
-      apt-get install -y --no-install-recommends \
-        -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
-        iperf3 || echo "⚠️  iperf3 install had issues (non-critical)"
+          # Atomic Red Team (ground truth reproducible — DEBT-ARGUSPP-MITRE-001)
+          if [ ! -d /opt/atomic-red-team ]; then
+            git clone --depth 1 \
+              https://github.com/redcanaryco/atomic-red-team.git \
+              /opt/atomic-red-team || \
+              echo "⚠️  atomic-red-team clone failed — red team offline mode"
+          fi
 
-      # Configure routing
-      ip route del default 2>/dev/null || true
-      ip route add default via 192.168.100.1 dev eth1
+          # NTP sync — community_id requiere timestamps coherentes
+          systemctl enable chrony
+          systemctl start chrony
+          chronyc makestep 1.0 3 2>/dev/null || true
 
-      # DNS
-      echo "nameserver 8.8.8.8" > /etc/resolv.conf
-      echo "nameserver 1.1.1.1" >> /etc/resolv.conf
+          # Routing hacia defender
+          ip route del default 2>/dev/null || true
+          ip route add default via 192.168.100.1 dev eth1
 
-      echo "✅ CLIENT READY"
-      echo "   IP: 192.168.100.50"
-      echo "   Gateway: 192.168.100.1 (defender eth2)"
-    CLIENT
+          echo "nameserver 8.8.8.8" > /etc/resolv.conf
+          echo "nameserver 1.1.1.1" >> /etc/resolv.conf
+
+          echo "=== CLIENT READY ==="
+          echo "   IP      : 192.168.100.50"
+          echo "   Gateway : 192.168.100.1 (defender eth2)"
+          echo "   Tools   : nmap hydra sqlmap tcpreplay atomic-red-team"
+        CLIENT
 
   end  # End client VM
 
+# ════════════════════════════════════════════════════════════════════════════
+  # SURICATA VM — IDS signatures (ADR-048 F2)
+  # autostart: false — arrancar con: vagrant up suricata
+  # community_id: yes — primary key para join cross-tool
+  # ════════════════════════════════════════════════════════════════════════════
+  config.vm.define "suricata", autostart: false do |suricata|
+    suricata.vm.box         = "debian/bookworm64"
+    suricata.vm.box_version = "12.20240905.1"
+    suricata.vm.hostname    = "argus-suricata"
+
+    suricata.vm.provider "virtualbox" do |vb|
+      vb.name   = "argus-suricata"
+      vb.memory = "2048"
+      vb.cpus   = 2
+      vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
+      vb.customize ["modifyvm", :id, "--nictype2", "virtio"]
+      vb.customize ["modifyvm", :id, "--nicpromisc2", "allow-all"]
+      vb.customize ["modifyvm", :id, "--ioapic", "on"]
+      vb.customize ["modifyvm", :id, "--audio", "none"]
+      vb.customize ["modifyvm", :id, "--usb", "off"]
+    end
+
+    # eth0: NAT (Vagrant management)
+    # eth1: 192.168.100.10 — argus experiment LAN (mismo intnet que defender eth2)
+    suricata.vm.network "private_network",
+      ip: "192.168.100.10",
+      virtualbox__intnet: "ml_defender_gateway_lan"
+
+    suricata.vm.synced_folder ".", "/vagrant", type: "virtualbox",
+      mount_options: ["dmode=775,fmode=775,exec"]
+
+    suricata.vm.provision "shell", name: "install-suricata", inline: <<-SHELL
+      set -e
+      export DEBIAN_FRONTEND=noninteractive
+      echo "=== Installing Suricata + ET Open rules (ADR-048 F2) ==="
+
+      apt-get update -qq
+      apt-get install -y suricata suricata-update \
+        tcpreplay net-tools curl jq python3 procps chrony
+
+      suricata --build-info | grep "^Version"
+
+      # NTP sync — community_id requiere timestamps coherentes (ADR-046 P0)
+      systemctl enable chrony
+      systemctl start chrony
+      chronyc makestep 1.0 3 2>/dev/null || true
+
+      # Reglas ET Open
+      suricata-update --no-reload
+      echo "Rules: $(find /var/lib/suricata/rules -name '*.rules' 2>/dev/null | head -1)"
+
+      # Interfaz: eth1 es la intnet compartida con defender
+      sed -i 's/- interface: eth0/- interface: eth1/' /etc/suricata/suricata.yaml
+      ip link set eth1 promisc on || true
+      echo 'ip link set eth1 promisc on' >> /etc/rc.local
+      chmod +x /etc/rc.local
+
+      # community-id: yes — primary key para join con Zeek/aRGus (DEBT-ARGUSPP-COMMUNITY-ID-001)
+      if grep -q "community-id: false" /etc/suricata/suricata.yaml; then
+        sed -i 's/community-id: false/community-id: yes/' /etc/suricata/suricata.yaml
+      else
+        sed -i '/eve-log:/a\      community-id: yes' /etc/suricata/suricata.yaml
+      fi
+
+      # eve.json accesible desde correlation-engine
+      mkdir -p /var/log/suricata
+      chown -R suricata:suricata /var/log/suricata 2>/dev/null || true
+
+      # Verificar community-id en config
+      grep "community-id" /etc/suricata/suricata.yaml || \
+        echo "⚠️  community-id no encontrado en suricata.yaml"
+
+      echo "=== Suricata ready ==="
+      suricata --build-info | grep -E "Version|AF_PACKET|PCAP"
+      echo "community-id: $(grep 'community-id' /etc/suricata/suricata.yaml | head -1)"
+    SHELL
+  end  # End suricata VM
+
+  # ════════════════════════════════════════════════════════════════════════════
+  # ZEEK VM — protocol analysis / observability layer (ADR-048 F3)
+  # autostart: false — arrancar con: vagrant up zeek
+  # community_id: obligatorio — mismo primary key que Suricata
+  # ════════════════════════════════════════════════════════════════════════════
+  config.vm.define "zeek", autostart: false do |zeek|
+    zeek.vm.box         = "debian/bookworm64"
+    zeek.vm.box_version = "12.20240905.1"
+    zeek.vm.hostname    = "argus-zeek"
+
+    zeek.vm.provider "virtualbox" do |vb|
+      vb.name   = "argus-zeek"
+      vb.memory = "2048"
+      vb.cpus   = 2
+      vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
+      vb.customize ["modifyvm", :id, "--nictype2", "virtio"]
+      vb.customize ["modifyvm", :id, "--nicpromisc2", "allow-all"]
+      vb.customize ["modifyvm", :id, "--ioapic", "on"]
+      vb.customize ["modifyvm", :id, "--audio", "none"]
+      vb.customize ["modifyvm", :id, "--usb", "off"]
+    end
+
+    # eth1: 192.168.100.11 — argus experiment LAN
+    zeek.vm.network "private_network",
+      ip: "192.168.100.11",
+      virtualbox__intnet: "ml_defender_gateway_lan"
+
+    zeek.vm.synced_folder ".", "/vagrant", type: "virtualbox",
+      mount_options: ["dmode=775,fmode=775,exec"]
+
+    zeek.vm.provision "shell", name: "install-zeek", inline: <<-SHELL
+      set -e
+      export DEBIAN_FRONTEND=noninteractive
+      echo "=== Installing Zeek (ADR-048 F3) ==="
+
+      apt-get update -qq
+      apt-get install -y curl gnupg2 chrony net-tools procps
+
+      # NTP sync
+      systemctl enable chrony
+      systemctl start chrony
+      chronyc makestep 1.0 3 2>/dev/null || true
+
+      # Zeek repo oficial
+      echo 'deb http://download.opensuse.org/repositories/security:/zeek/Debian_12/ /' \
+        > /etc/apt/sources.list.d/zeek.list
+      curl -fsSL https://download.opensuse.org/repositories/security:/zeek/Debian_12/Release.key \
+        | gpg --dearmor > /etc/apt/trusted.gpg.d/zeek.gpg
+      apt-get update -qq
+      apt-get install -y zeek
+
+      # PATH
+      echo 'export PATH=/opt/zeek/bin:$PATH' >> /etc/profile.d/zeek.sh
+      chmod +x /etc/profile.d/zeek.sh
+      export PATH=/opt/zeek/bin:$PATH
+
+      # Configurar interfaz eth1
+      sed -i 's/interface=eth0/interface=eth1/' /opt/zeek/etc/node.cfg
+
+      # community-id — DEBT-ARGUSPP-COMMUNITY-ID-001
+      # Zeek 5.x incluye community-id nativo via policy/protocols/conn/community-id-v1.zeek
+      if [ ! -f /opt/zeek/etc/local.zeek ]; then
+        touch /opt/zeek/etc/local.zeek
+      fi
+      if ! grep -q "community-id" /opt/zeek/etc/local.zeek; then
+        echo "@load policy/protocols/conn/community-id-v1" >> /opt/zeek/etc/local.zeek
+        echo "✅ community-id añadido a local.zeek"
+      fi
+
+      # Logs en /var/log/zeek para acceso desde correlation-engine
+      mkdir -p /var/log/zeek
+      ln -sf /opt/zeek/logs/current /var/log/zeek/current 2>/dev/null || true
+
+      /opt/zeek/bin/zeek --version
+      echo "=== Zeek ready ==="
+      echo "community-id: $(grep community-id /opt/zeek/etc/local.zeek)"
+    SHELL
+  end  # End zeek VM
+
+  # ════════════════════════════════════════════════════════════════════════════
+  # WAZUH VM — host-based events / HIDS (ADR-048 F4)
+  # autostart: false — arrancar con: vagrant up wazuh
+  # 4096MB — Wazuh manager es Java, necesita más RAM
+  # ════════════════════════════════════════════════════════════════════════════
+  config.vm.define "wazuh", autostart: false do |wazuh|
+    wazuh.vm.box         = "debian/bookworm64"
+    wazuh.vm.box_version = "12.20240905.1"
+    wazuh.vm.hostname    = "argus-wazuh"
+
+    wazuh.vm.provider "virtualbox" do |vb|
+      vb.name   = "argus-wazuh"
+      vb.memory = "4096"
+      vb.cpus   = 2
+      vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
+      vb.customize ["modifyvm", :id, "--nictype2", "virtio"]
+      vb.customize ["modifyvm", :id, "--ioapic", "on"]
+      vb.customize ["modifyvm", :id, "--audio", "none"]
+      vb.customize ["modifyvm", :id, "--usb", "off"]
+    end
+
+    # eth1: 192.168.100.12 — argus experiment LAN
+    wazuh.vm.network "private_network",
+      ip: "192.168.100.12",
+      virtualbox__intnet: "ml_defender_gateway_lan"
+
+    wazuh.vm.synced_folder ".", "/vagrant", type: "virtualbox",
+      mount_options: ["dmode=775,fmode=775,exec"]
+
+    wazuh.vm.provision "shell", name: "install-wazuh", inline: <<-SHELL
+      set -e
+      export DEBIAN_FRONTEND=noninteractive
+      echo "=== Installing Wazuh manager (ADR-048 F4) ==="
+
+      apt-get update -qq
+      apt-get install -y curl gnupg2 chrony net-tools procps
+
+      # NTP sync
+      systemctl enable chrony
+      systemctl start chrony
+      chronyc makestep 1.0 3 2>/dev/null || true
+
+      # Wazuh repo
+      curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH \
+        | gpg --dearmor > /usr/share/keyrings/wazuh.gpg
+      echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" \
+        > /etc/apt/sources.list.d/wazuh.list
+      apt-get update -qq
+
+      # Manager
+      # WAZUH_MANAGER_PASSWORD se inyecta desde el entorno del host
+      # export WAZUH_MANAGER_PASSWORD=<valor> antes de vagrant up wazuh
+      # En dev sin password configurado: Wazuh usa el default interno
+      apt-get install -y wazuh-manager
+
+      systemctl daemon-reload
+      systemctl enable wazuh-manager
+      systemctl start wazuh-manager
+
+      echo "=== Wazuh manager ready ==="
+      /var/ossec/bin/wazuh-control status | head -5
+    SHELL
+  end  # End wazuh VM
 end  # End Vagrant configuration

--- a/docs/continuity/PROMPT_CONTINUE_CLAUDE.md
+++ b/docs/continuity/PROMPT_CONTINUE_CLAUDE.md
@@ -1,32 +1,32 @@
-DAY 164 — aRGus NDR (arXiv:2604.04952)
+DAY 168 — aRGus NDR (arXiv:2604.04952)
 
-Estado: main @ v1.0.0-day166. EMECAS++ 3 actos verdes. Rama enterprise mergeada.
+Estado: main @ post-merge feature/day167-ntp-correlation-engine. EMECAS++ 3 actos verdes.
 
-PRIORIDAD DAY 164:
-BACKLOG-CI-ENTERPRISE-001 — Jenkins gate `make emecas++` (post-merge, hardware FEDER pendiente).
-ADR-048 F2 — DEBT-ARGUSPP-NTP-001 (NTP+chrony P0) + DEBT-ARGUSPP-COMMUNITY-ID-001 (P0).
-DEBT-ARGUSPP-SURICATA-001 — Integrar Suricata en Vagrantfile + EMECAS.
+CONTEXTO DE LOS ÚLTIMOS DÍAS:
+DAY 163: Fix CMake (test_ntp_health_check triplicado). BACKLOG-CRYPTO-VENDOR-KEY-001 ✅.
+CryptoProviderHandle RCU ✅. ADR-045 v2 ✅. Consejo 8/8.
+DAY 164-166: Enterprise crypto lifecycle completo. EMECAS++ 3 actos. Merge a main.
+DAY 167: NTP+chrony (DEBT-ARGUSPP-NTP-001 P0) + correlation engine (ADR-048 F2).
+11 pasadas para ajustar Jenkins. EMECAS++ verde. Merge a main.
 
-CERRADO DAY 163:
-- Bug CMake: test_ntp_health_check triplicado en common/CMakeLists.txt. Fix: sed elimina líneas 291-302 y 387-398. EMECAS++ verde en 1h 3m 26s.
-- BACKLOG-CRYPTO-VENDOR-KEY-001 ✅ (Modelo B efímero).
-- BACKLOG-CRYPTO-HOT-RELOAD-001 ✅ (CryptoProviderHandle RCU 9/9 tests).
-- ADR-045 v2 aprobado (Consejo 8/8).
-- DEBT-CMAKE-GRAPH-INVARIANTS-001 abierta (lint CI, propuesta ADR-028).
+PRIORIDAD DAY 168 (por completar ADR-048 F2):
+- DEBT-ARGUSPP-COMMUNITY-ID-001 — habilitar community_id en Suricata y Zeek (P0 en v1.1)
+- DEBT-ARGUSPP-SURICATA-001 — Suricata en Vagrantfile + EMECAS, eve.json → rag-security
+- BACKLOG-CI-ENTERPRISE-001 — Jenkins gate `make emecas++` (P1 post-merge)
 
-CONSEJO DAY 163 (8/8):
-- P1 CMake: `if(NOT TARGET)` invariante obligatorio. Bloques condicionales no crean targets.
-- P2 Fase 1: AppRole + vendor.key + test aislamiento = los tres o no cierra (posición dura Claude/ChatGPT/Grok/Kimi/DeepSeek). Gemini/Qwen aceptan ENV VAR sola como Fase 1.
-- P3 Acto I: suficiente con compilación + UTs hasta cerrar BACKLOG-CRYPTO-VENDOR-KEY-001.
-- Pendiente responder a Gemini: ciclo de vida credencial temporal Jenkins→Vault.
-- Typo "DAY 167" en commit: regresión fue sesión anterior sin número asignado.
+DEUDAS NUEVAS DAY 163:
+- DEBT-CMAKE-GRAPH-INVARIANTS-001 — lint CI targets duplicados CMake (P1)
+- BACKLOG-EMECAS-VAULT-E2E-001 — cubierto por EMECAS++ Acto I
 
-REGLAS NUEVAS:
+REGLAS CRÍTICAS:
 - if(NOT TARGET) obligatorio en bloques CMake condicionales.
-- EMECAS++ = 3 actos (I arranque Vault, II rotación live, III Vault fault inject zero downtime).
-- VaultProvider caché RCU implementación del Acto III.
+- EMECAS++ = 3 actos antes de cualquier merge enterprise. Tarda >1h. No negociable.
+- Python3 heredoc en macOS. vagrant ssh -c siempre con -c. -Werror permanente.
+- Nunca merge directo a main — siempre PR con EMECAS++ verde.
+- vendor.key nunca en disco ni en repo — solo Vault dev (Modelo B).
+- ZMQ PUB hace bind() ANTES de SUB connect().
 
-ENTORNO: macOS M2 Pro, Vagrant/VirtualBox Debian Bookworm, vagrant/dev/.
-STACK: ZeroMQ + ChaCha20-Poly1305 + Ed25519 + libsodium 1.0.19, eBPF/XDP, etcd-server, Vault dev.
-KEYPAIR ACTIVO: c76e5e10e2a5a5ebcbf249a2d36a2a18d88b05aa75552bb7042353221484cf90 (efímero, regenera en EMECAS).
-REGLA: Python3 heredoc en macOS. vagrant ssh -c siempre con -c. -Werror permanente. Nunca direct merge a main. EMECAS++ antes de cualquier merge enterprise.
+ENTORNO: macOS M2 Pro · Vagrant/VirtualBox Debian Bookworm · vagrant/dev/
+KEYPAIR: efímero, regenera en cada EMECAS.
+PAPER: arXiv:2604.04952 · Draft v24 local · v3 en arXiv.
+FEDER gate: datasets de valor científico para Dr. Andrés Caro Lindo (UEx/INCIBE).

--- a/docs/continuity/PROMPT_CONTINUE_CLAUDE.md
+++ b/docs/continuity/PROMPT_CONTINUE_CLAUDE.md
@@ -1,22 +1,53 @@
-DAY 168 — aRGus NDR (arXiv:2604.04952)
+DAY 169 — aRGus NDR (arXiv:2604.04952)
 
-Estado: main @ post-merge feature/day167-ntp-correlation-engine. EMECAS++ 3 actos verdes.
+Estado: main @ post-merge feature/day167-ntp-correlation-engine.
+Rama activa: feature/day168-suricata-community-id (pendiente EMECAS++ y merge).
 
 CONTEXTO DE LOS ÚLTIMOS DÍAS:
 DAY 163: Fix CMake (test_ntp_health_check triplicado). BACKLOG-CRYPTO-VENDOR-KEY-001 ✅.
 CryptoProviderHandle RCU ✅. ADR-045 v2 ✅. Consejo 8/8.
-DAY 164-166: Enterprise crypto lifecycle completo. EMECAS++ 3 actos. Merge a main.
-DAY 167: NTP+chrony (DEBT-ARGUSPP-NTP-001 P0) + correlation engine (ADR-048 F2).
-11 pasadas para ajustar Jenkins. EMECAS++ verde. Merge a main.
+DAY 164-166: Enterprise crypto lifecycle completo. EMECAS++ 3 actos. Merge a main. Tag v1.0.0-day166.
+DAY 167: NTP+chrony (DEBT-ARGUSPP-NTP-001 P0) + correlation engine scaffold (ADR-048 F2).
+11 pasadas Jenkins. EMECAS++ verde. Merge a main → 7b45feca.
+DAY 168: Vagrantfile multi-VM: Suricata 7.0.10 + Zeek 8.2.0 + Wazuh 4.x provisionados.
+Todos en ml_defender_gateway_lan (192.168.100.0/24).
+community-id habilitado en Suricata y Zeek (DEBT-ARGUSPP-COMMUNITY-ID-001 ✅).
+REGLA NUEVA: nunca set -e en provisions Vagrantfile — usar || true o || { exit 1; }.
+REGLA NUEVA: DNS fix (chattr +i /etc/resolv.conf) SIEMPRE después de instalar chrony.
+REGLA NUEVA: nunca cat << 'EOF' anidado en <<-SHELL — usar printf.
+Commits: feat(suricata/zeek/wazuh), fix(security) WAZUH_MANAGER_PASSWORD eliminado.
 
-PRIORIDAD DAY 168 (por completar ADR-048 F2):
-- DEBT-ARGUSPP-COMMUNITY-ID-001 — habilitar community_id en Suricata y Zeek (P0 en v1.1)
-- DEBT-ARGUSPP-SURICATA-001 — Suricata en Vagrantfile + EMECAS, eve.json → rag-security
-- BACKLOG-CI-ENTERPRISE-001 — Jenkins gate `make emecas++` (P1 post-merge)
+VMs ACTIVAS (autostart: false — arrancar individualmente):
+defender   192.168.100.1   aRGus NDR completo (primary)
+suricata   192.168.100.10  Suricata 7.0.10, AF_PACKET, community-id:yes, PROMISC ✅
+zeek       192.168.100.11  Zeek 8.2.0, community-id-v1, PROMISC ✅
+wazuh      192.168.100.12  Wazuh 4.x manager running, NTP OK ✅
+client     192.168.100.50  tcpreplay + nmap/hydra/sqlmap/atomic-red-team (autostart:false)
 
-DEUDAS NUEVAS DAY 163:
-- DEBT-CMAKE-GRAPH-INVARIANTS-001 — lint CI targets duplicados CMake (P1)
-- BACKLOG-EMECAS-VAULT-E2E-001 — cubierto por EMECAS++ Acto I
+PRIORIDAD DAY 169:
+1. EMECAS++ en feature/day168-suricata-community-id → PR → merge a main (P0)
+2. DEBT-ARGUSPP-COMMUNITY-ID-001 — community_id en contrato protobuf + sniffer
+   - cat protobuf/network_security.proto → añadir campo community_id (string, field ~20)
+   - sniffer: calcular community_id (SHA1 5-tupla: src_ip+dst_ip+src_port+dst_port+proto)
+   - propagar por pipeline: ml-detector → correlation-engine
+   - protobuf3 backwards compatible — campos nuevos no rompen componentes existentes
+   source_wait_timeout: argus=5s / suricata=10s / zeek=20s / wazuh=90s
+   crisis_idle_timeout: 120s
+3. BACKLOG-CI-ENTERPRISE-001 — Jenkins gate make emecas++ (P1)
+4. DEBT-CMAKE-GRAPH-INVARIANTS-001 — lint CI targets duplicados CMake (P1)
+
+DEUDAS ABIERTAS RELEVANTES:
+- DEBT-ARGUSPP-SURICATA-001 — Suricata en EMECAS + eve.json → correlation-engine
+- DEBT-ARGUSPP-COMMUNITY-ID-001 — Suricata+Zeek OK; falta verificar en outputs reales
+- DEBT-ARGUSPP-WAZUH-001 — Wazuh password via Vault en prod FEDER
+- DEBT-ARGUSPP-MITRE-001 — script de ataque MITRE con atomic-red-team (post-FEDER)
+- DEBT-CMAKE-GRAPH-INVARIANTS-001 — lint CI targets duplicados CMake
+
+ARQUITECTURA MULTI-VM (ml_defender_gateway_lan 192.168.100.0/24):
+- eth0: NAT (gestión)
+- eth1: intnet ml_defender_gateway_lan (tráfico de ataque, promiscuo en sniffer/suricata/zeek)
+- client inyecta tráfico → todos los engines ven el mismo flujo → community_id coherente
+- Neo4j: grafo de correlación cross-engine sobre community_id (post-FEDER)
 
 REGLAS CRÍTICAS:
 - if(NOT TARGET) obligatorio en bloques CMake condicionales.
@@ -25,8 +56,11 @@ REGLAS CRÍTICAS:
 - Nunca merge directo a main — siempre PR con EMECAS++ verde.
 - vendor.key nunca en disco ni en repo — solo Vault dev (Modelo B).
 - ZMQ PUB hace bind() ANTES de SUB connect().
+- Nunca set -e en provisions Vagrantfile — usar || true o || { exit 1; } explícito.
+- DNS fix en todos los provisions nuevos: chattr +i /etc/resolv.conf DESPUÉS de chrony.
+- Nunca cat << 'EOF' anidado en <<-SHELL — usar printf.
 
-ENTORNO: macOS M2 Pro · Vagrant/VirtualBox Debian Bookworm · vagrant/dev/
+ENTORNO: macOS M2 Pro · i9 8 núcleos · 32GB RAM · Vagrant/VirtualBox Debian Bookworm · vagrant/dev/
 KEYPAIR: efímero, regenera en cada EMECAS.
 PAPER: arXiv:2604.04952 · Draft v24 local · v3 en arXiv.
-FEDER gate: datasets de valor científico para Dr. Andrés Caro Lindo (UEx/INCIBE).
+FEDER gate: 22 septiembre 2026 · datasets para Dr. Andrés Caro Lindo (UEx/INCIBE).


### PR DESCRIPTION
## Changes
- Suricata 7.0.10: AF_PACKET, community-id:yes, PROMISC, 50248 reglas ET Open
- Zeek 8.2.0: community-id-v1, PROMISC
- Wazuh 4.x: manager running, NTP OK
- Todos en ml_defender_gateway_lan (192.168.100.0/24)
- client VM: upgrade con nmap/hydra/sqlmap/atomic-red-team
- DNS fix permanente: chattr +i tras chrony (regla nueva)
- Prompt DAY 169 actualizado con protobuf + sniffer community_id

## Gate
EMECAS++ requerido antes de merge.

## Deudas cerradas
- DEBT-ARGUSPP-COMMUNITY-ID-001: Suricata+Zeek configurados ✅

## Deudas abiertas
- DEBT-ARGUSPP-SURICATA-001: eve.json → correlation-engine
- DEBT-ARGUSPP-COMMUNITY-ID-001: protobuf + sniffer (DAY 169)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three optional security monitoring VMs: network traffic analysis, observability, and host-based threat detection capabilities.
  * Enhanced client environment with additional security and monitoring tools.

* **Documentation**
  * Updated continuity documentation reflecting latest environment configuration and priorities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alonsoir/argus/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->