### PR TITLE
fix(correlation_writer): Stats::current_final_path — cierra DEBT-CORR…

### DIFF
--- a/docs/continuity/PROMPT_CONTINUE_CLAUDE.md
+++ b/docs/continuity/PROMPT_CONTINUE_CLAUDE.md
@@ -1,98 +1,71 @@
-# PROMPT DE CONTINUIDAD — DAY 199 (continúa DAY 198)
+# PROMPT DE CONTINUIDAD — DAY 204 (continúa DAY 203)
 # Instrucciones generales para Claude:
 
-1. Piensa antes de codificar  
-Expón tus suposiciones. Pregunta cuando no estés seguro. Nunca adivines.
+1. Piensa antes de codificar
+   Expón tus suposiciones. Pregunta cuando no estés seguro. Nunca adivines.
 
-2. Simplicidad primero  
-Escribe el código mínimo que resuelva el problema.  
-Sin abstracciones que nadie pidió.
+2. Simplicidad primero
+   Escribe el código mínimo que resuelva el problema.
+   Sin abstracciones que nadie pidió.
 
-3. Cambios quirúrgicos  
-No toques código no relacionado con la solicitud.  
-Cada línea cambiada debe rastrearse hasta lo que se pidió.
+3. Cambios quirúrgicos
+   No toques código no relacionado con la solicitud.
+   Cada línea cambiada debe rastrearse hasta lo que se pidió.
 
-4. Ejecución orientada a metas  
-Convierte instrucciones vagas en criterios de éxito verificables  
-antes de escribir una sola línea.
+4. Ejecución orientada a metas
+   Convierte instrucciones vagas en criterios de éxito verificables
+   antes de escribir una sola línea.
 
 ## Invariantes
 - **medir, no votar** — verificar contra fichero, nunca contra memoria; trazar hacia atrás desde el binario.
 - **JSON is the law** · **bronce PRESERVA, gold DECIDE** · **Via Appia** (ledger inmutable durable y verificable; Kuzu = proyección reconstruible).
-- **EMECAS++** antes de cualquier merge · **PR obligatorio** (commit de doc no pasa el gate de build).
+- **EMECAS++** antes de cualquier merge · **PR obligatorio**.
 - **Consejo de Sabios** (8 modelos) ratifica decisiones de arquitectura.
-- Python3 heredoc (lectura→memoria→escritura, NUNCA `open(p,'w')` y `read()` en la misma expresión: trunca a 0) para editar ficheros en macOS · NUNCA `sed -i` en macOS · `vagrant ssh -c` para todo comando del VM · commits/push desde el HOST (el guest Debian no tiene identidad git/GitHub).
-- Un día, una batalla.
+- Python3 heredoc (lectura→memoria→escritura) para editar ficheros en macOS · NUNCA `sed -i` · `vagrant ssh -c` para comandos del VM · commits/push desde el HOST.
+- Un día, una batalla. Features pequeñas (días, no semanas), merge frecuente a main vía EMECAS++.
 
-## DAY 200 — TAREA 1 (bloqueante, antes de Eslabón 0): reconciliar docs/BACKLOG.md con las deudas del circuito. 
-Medido DAY 199 (grep -c contra el fichero): de las ~19 deudas que ADR-058 §6 cita como existentes, solo 2 tienen entrada
-formal en BACKLOG.md (DEBT-FLOWUID-SEQ-COLLISION-001, DEBT-FLOWUID-CANONICAL-ENCODING-001). 
-El resto existe como mención en ADR/plan/actas, no como entrada de backlog. 
-Trabajo: (a) 4 deudas nuevas del V3, todas P1 — DEBT-CIRCUIT-SCORE-NONTRIVIAL-REVAL-001, 
-DEBT-CIRCUIT-PARSER-CROSSLANG-001, DEBT-EVENT-ID-FACTORY-001, y reclasificación P2→P1 + alcance ampliado de
-DEBT-CIRCUIT-TEMPORAL-ANOMALY-PARITY-001; (b) deudas DAY 196-199 del circuito que faltan — 
-al menos DEBT-CIRCUIT-BRONZE-ROTATION-FOLLOW-001, DEBT-CONFIG-BRONZE-HARDCODE-001, DEBT-GOLD-NODE-DIMENSION-001 
-(ampliada con flow_start_window), DEBT-GOLD-INTEGRITY-HMAC-001, DEBT-ZMQ-DELIVERY-GUARANTEE-001, 
-DEBT-HOST-DOMAIN-CONTRACT-001, DEBT-PARQUET-KUZU-CONNECTOR-001 (ampliada con orden Flujo B), 
-DEBT-CIRCUIT-FS-DROP-001, DEBT-PARSE-VERIFY-SENTINEL-001 (degradada P0→P2),
-DEBT-ADAPTERSPEC-ENVELOPE-001, DEBT-DOCS-MEDALLION-DUALITY-001, DEBT-JOIN-CONFIDENCE-001; 
-(c) resolver drift de ID: ADR-058 cita DEBT-NEO4J-FLOW-KEY-COMPOSITE-001; 
-el backlog tiene DEBT-NEO4J-FLOW-KEY-001 (DAY 170). Decidir canónico.
-MÉTODO (lección DEDUP, DAY 158, no negociable): una sola pasada, fuente canónica de cada deuda decidida ANTES de escribir 
-(preferir la definición más completa del plan del circuito sobre reinventar), script append-only idempotente que aborta 
-si el nombre ya existe, gate de cierre grep '^### DEBT\|^## ' docs/BACKLOG.md | sort | uniq -d = 0. NO cat >> a mano. 
-Eslabón 0 (config bronce JSON + watcher inotify/IN_CLOSE_WRITE + escritura atómica .tmp→rename, 
-cierra DEBT-CONFIG-BRONZE-HARDCODE-001 + DEBT-CIRCUIT-BRONZE-ROTATION-FOLLOW-001) pasa a DAY 201. 
+## Estado al cierre de DAY 203 — Eslabón 0 CERRADO (3/3 sub-features, merge a main)
 
-Recordar: la atomicidad es de ROTACIÓN (cambio de día), NO de append.
+**DAY 203 fue una sesión larga (06:00–14:11) y productiva.** Tres PRs pequeños, cada uno su propio EMECAS++ verde, merge inmediato a main:
 
-## Estado al cierre de DAY 198
-- **GATE DEL CIRCUITO CERRADO 9/9 CONTRA BYTES.** Las 9 verificaciones medidas, cero apoyo en memoria:
-    1. `flow_start_window` es **derivada** (writer escribe sec+nano `correlation_writer.cpp:88-89`; reader computa window en read-time `main.cpp:117`). Decisión: **materializar en oro como columna hash-input** (precondición Via Appia). `DEBT-GOLD-NODE-DIMENSION-001` ampliada.
-    2. Centinela `-1`: **FANTASMA en puertos**. Proto `uint32` e2e (`network_security.proto:105-106`), sniffer usa `0` para ICMP (`test_community_id.cpp:62`), writer copia directa (`correlation_writer.cpp:91-92`), reader `from_chars` acepta `0`. `DEBT-PARSE-VERIFY-SENTINEL-001` **degradada P0→P2**. Riesgo residual: `flow_start_sec`/`nano` son signed (`int64/int32`), `-1` sobrevive como valor (semántico, P2).
-    3. Writer rota por fecha (`correlation_writer.cpp:177`), reader abre handle fijo (`main.cpp:104`), `--follow` no sigue rotación (`main.cpp:125-132`) → **roja BENIGNA**, Eslabón 0 parchea. P0: `DEBT-CIRCUIT-BRONZE-ROTATION-FOLLOW-001`, `DEBT-CONFIG-BRONZE-HARDCODE-001`.
-    4. day194: PR #107 mergeado (`77a3de9c`), no-bloqueo.
-       5-6. Sniffer/writer puerto sin centinela negativo.
-    7. Verbo Cypher = **MERGE** ambos paths (`cypher_builder.hpp:100,154`), solo `ON CREATE SET`, cero `ON MATCH` → equivalencia robusta a colisión `flow_uid` (segundo flujo descartado idéntico en ambos caminos). Colisión = fidelidad P2, NO equivalencia.
-    8. Interpolación L154 vive solo en `build_cypher()`/logging (`logging_graph_sink.cpp:27`), no toca BD; producción usa prepared `$param` → **ADR-057 intacto**.
-    9. Encoding `flow_uid` **canónico** (`flow_uid.hpp`): BLAKE2b-256 sin truncado, length-prefix `uint16` BE por string, window/seq enteros BE de ancho fijo, tag `"argus-flowuid-v1"` (16B), **paridad C++↔`hashlib.blake2b` congelada**. `DEBT-FLOWUID-CANONICAL-ENCODING-001` **resuelta de facto**.
-- **ADR-058 commiteado en `day196`** (commit `47d0a8d6`, 315 líneas, LF puro). Fichero: `docs/adr/ADR-058-circuito-completo-aguas-abajo.md`. Pendiente: **push de `day196` + PR del circuito + subir al Consejo para ratificación 9/9**.
-- **HIGIENE DOCUMENTAL MERGEADA** (PR `88ee842d` → main): 49 renames `(100%)`, `docs/adr` canónico `ADR-NNN[-vN]-slug.md`, `docs/debt`+`docs/backlog` consolidados, `docs/debts` eliminado, historia git preservada. `day196` ya trae la higiene vía fast-forward (`ddc9f754..68031662`). Rama `day198/docs-adr-naming-hygiene` borrable.
+1. **DAY 201** — `correlation_writer.base_dir` desde JSON (mitad WRITER de `DEBT-CONFIG-BRONZE-HARDCODE-001`). Merged.
+2. **DAY 202** — `correlation-engine` deriva `bronze_root` desde `correlation_engine.json` nuevo (mitad READER de la misma deuda). JSON con esqueleto completo (component/node_id/profiles/etcd) para crecimiento incremental — solo `bronze.root_dir` consumido hoy. Merged.
+3. **DAY 203** — Bronce SEGMENTADO + escritura atómica `.tmp→rename` + `BronzeDirWatcher` (inotify puro, `IN_MOVED_TO`) en el reader. Cierra `DEBT-CIRCUIT-BRONZE-ROTATION-FOLLOW-001`. Merged (`aa74dcd0..6808e847`).
 
-## Decisión VIVA para el Consejo
-Una sola, consciente (no hueco): **tolerancia ε en los 3 scores double** (cols 14-16) del predicado de equivalencia §3.1 del ADR-058. El path de producción usa binding nativo (sin pérdida); el Flujo A+B serializa double→Parquet→double (no bit-exacto). El predicado compara con ε, no bit-a-bit. No medible hasta que exista el Flujo A. El Consejo lo ratifica como criterio del test de equivalencia.
+**Diseño DAY 203 (verificado en VM real, no solo en teoría):**
+- Writer: cada segmento `<fecha>-<HHMMSS-apertura>.csv`, escrito a `.csv.tmp`, cerrado+renombrado atómicamente al rotar. Rotación por **tiempo absoluto desde apertura** (`correlation_writer.rotation_seconds`, JSON, default **30s** — valor elegido explícitamente para el prototipo del Eslabón 0, ver nota de Alonso: "esto es para asegurar que todo funciona con una aproximación basada en leer ficheros del FS estando las dos ramas en el mismo FS"; en producción real, componentes en intranets distintas del servidor central, el valor sube).
+- Reader: `BronzeDirWatcher` nuevo en `correlation-engine` (NO enlaza rag-ingester — reescrito desde cero calcando el patrón de `CsvDirWatcher` de rag-ingester, pero con semántica distinta: `IN_MOVED_TO` sobre segmentos ya inmutables, no `IN_MODIFY`+offset sobre un fichero que nunca se cierra). Modo directorio nuevo (replay de segmentos existentes + `--follow` con watcher bloqueante) coexiste con el modo legacy `--bronze`/`ARGUS_BRONZE_CSV` explícito, que queda **intacto** — compatibilidad total con tests/scripts existentes.
+- **Verificado en corrida real de EMECAS++:** segmentos rotando cada ~30-70s bajo carga sintética (la variación por encima de 30s es esperada: `rotate_if_needed()` solo se evalúa al llegar un evento nuevo, no hay timer independiente — anotado, no es bug). Cero fallos de rename atómico en el log. 3 `.tmp` huérfanos al final de la corrida, esperados (proceso detenido a media escritura).
 
-## Acciones DAY 199 (en orden)
-1. **[push pendiente]** `git push -u origin day196/circuit-adapters-zmq` (desde el host). Abrir PR del circuito. Subir ADR-058 al Consejo.
-2. **→ Eslabón 0 (primera implementación real del circuito):** config bronce a JSON (`bronze_root` + patrón naming, calcado de `csv_writer` `config_loader.cpp:455`) + watcher `inotify`/`IN_CLOSE_WRITE` + escritura atómica `.tmp`→rename + cierre por tiempo absoluto. Cierra `DEBT-CONFIG-BRONZE-HARDCODE-001` + `DEBT-CIRCUIT-BRONZE-ROTATION-FOLLOW-001` (ambas P0). El ADR-058 es el commit de apertura del mismo PR.
-3. Tras Eslabón 0 verde → **Eslabón 1** (Flujo A: bronce→AVRO→Parquet oro, greenfield) con `flow_start_window` materializada + HMAC-SHA256 por-fila heredado + firma Parquet **greenfield HMAC, NO el Ed25519 de RAG-127** (`DEBT-DOCS-MEDALLION-DUALITY-001`).
+**Hallazgo importante DAY 203 (no bloqueante, pero real):** al verificar por qué EMECAS++ pasaba verde tras un cambio de arquitectura de rotación tan grande, se descubrió que `test_correlation_roundtrip.cpp` (en `ml-detector/tests/integration/`) **existe como fuente pero nunca estuvo enganchado a ningún `add_test`** — ni antes ni después de este cambio. No es una regresión introducida hoy; es una laguna de cobertura preexistente que nadie había verificado. Registrada como `DEBT-CORRELATION-ROUNDTRIP-ORPHANED-001` (P1) en `docs/BACKLOG.md`.
 
-## Criterio de cierre del medallón (del ADR-058 §3.1)
-Test de equivalencia **Camino-0 ≡ Flujo-A+B** sobre la proyección Kuzu. Predicado ancho:
-`set(flow_uid)` (NetworkFlow) ∧ `set(event_id)` (Alert∪TelemetryEvent) ∧ props_identidad (node_id, community_id, window, seq) ∧ props_veredicto ≈ε (cols 12-17, scores con tolerancia) ∧ aristas {ALERT_ABOUT, TELEMETRY_ABOUT, CORRELATES_FLOW} ∧ hmac_row preservado. **Cláusula de caducidad:** válido mientras el join sea determinista (10.8 / `DEBT-JOIN-CONFIDENCE-001`).
+## Acciones DAY 204 (en orden)
 
-## Deudas abiertas (prioridad)
-- **P0:** `DEBT-CIRCUIT-BRONZE-ROTATION-FOLLOW-001`, `DEBT-CONFIG-BRONZE-HARDCODE-001` (ambas → Eslabón 0), `DEBT-GOLD-NODE-DIMENSION-001` (incl. `flow_start_window`), `DEBT-GOLD-INTEGRITY-HMAC-001`, `DEBT-ZMQ-DELIVERY-GUARANTEE-001`
-- **P1:** `DEBT-HOST-DOMAIN-CONTRACT-001` (pre-Eslabón 1; Wazuh host↔red, deuda canónica `DEBT-ARGUSPP-WAZUH-001` F4; el nombre `host_domain_v1` NO existe en repo), `DEBT-PARQUET-KUZU-CONNECTOR-001` (greenfield Eslabón 2), `DEBT-CIRCUIT-FS-DROP-001`
-- **P2:** `DEBT-PARSE-VERIFY-SENTINEL-001` (degradada de P0; doc + vigilancia campos unsigned futuros), `DEBT-FLOWUID-SEQ-COLLISION-001` (seq=0; fidelidad, no equivalencia), `DEBT-NEO4J-FLOW-KEY-COMPOSITE-001` (PK compuesta `(flow_uid,seq)` no implementada), `DEBT-ADAPTERSPEC-ENVELOPE-001`, `DEBT-DOCS-MEDALLION-DUALITY-001`, `DEBT-JOIN-CONFIDENCE-001`
-- **resueltas DAY 198:** `DEBT-FLOWUID-CANONICAL-ENCODING-001` (de facto, encoding inyectivo + paridad congelada)
-- **P3:** higiene `backups/`/`.backup` + `.DS_Store` → `.gitignore` / `git rm --cached`
+1. **Revisar y actualizar tests.** Con el cambio de arquitectura de bronce (fichero único por día → segmentos rotados), verificar si algún test existente (`correlation-engine` GTest suite: `test_correlation_reader`, `test_graph_sink_loop`, `test_kuzu_graph_sink`, `test_cypher_prepared`) tiene supuestos implícitos sobre el formato de fichero de bronce que convenga actualizar o reforzar explícitamente contra el formato nuevo (`<fecha>-<HHMMSS>.csv`).
+2. **Cerrar `DEBT-CORRELATION-ROUNDTRIP-ORPHANED-001`** — enganchar `test_correlation_roundtrip.cpp` con `add_test` en `ml-detector/tests/CMakeLists.txt`, verificar que corre dentro de `test-all`/`test-components`, PASSED contra el bronce segmentado.
+3. **Evaluar si EMECAS++ necesita un protocolo nuevo (EMECAS+++, propuesto por Alonso DAY 203).** EMECAS/EMECAS++ validan "¿compila y pasan los tests de cada componente?" (mirada hacia el software de los componentes). El circuito que se está construyendo (adapters → bronce → LZ → Kuzu → dashboard) necesita además "¿fluye el dato extremo a extremo por el río?" — el test E2E que define ADR-058 §1 (inyectar evento sintético, verificar HMAC en bronce, verificar `MATCH` en Kuzu, fallar si cualquier paso cae). Decidir si esto se formaliza ya como target `make emecas+++` o se difiere hasta tener el primer tramo de Eslabón 1 vivo.
+4. **Poner al día `docs/BACKLOG.md`** — marcar como CERRADAS las entradas DAY200 correspondientes a `DEBT-CIRCUIT-BRONZE-ROTATION-FOLLOW-001` y `DEBT-CONFIG-BRONZE-HARDCODE-001` (Eslabón 0 las cierra ambas). Revisar si `rotation_seconds` merece nota propia de "valor de prototipo, no de producción" en la entrada correspondiente.
+5. **Poner al día `README.md`** — sección DAY-STATUS, hitos del día, tabla de estado global (Eslabón 0 pasa de 0% a 100%).
+6. **Higiene pendiente, no bloqueante:** limpiar basura en `/vagrant/logs/correlation/argus` de sesiones anteriores al patrón segmentado (`2026-06-*.csv`, `2026-07-01.csv` sin sufijo de hora) — vive en carpeta compartida host↔VM, `vagrant destroy` no la toca. Considerar si merece un target `make clean-logs` o similar.
+7. **Después de 1-4:** decidir si se abre ya Eslabón 1 (Landing Zone / Flujo A: bronce→AVRO→Parquet oro) o si primero conviene consolidar EMECAS+++ como gate formal antes de construir más río abajo.
 
-## Punteros (paths POST-higiene — nombres canónicos)
-- `docs/adr/ADR-058-circuito-completo-aguas-abajo.md` (commit `47d0a8d6`, en `day196`)
-- `docs/council/PLAN — Circuito completo aguas abajo (DAY 196 → implementación).md` (plan-doc consolidado DAY 197; `council/` NO normalizado, fuera de alcance de la higiene)
-- `docs/adr/ADR-052-v3.2-multi-node-flow-identity-host-net-correlation.md` (flow_uid identidad multi-nodo)
-- `docs/adr/ADR-057-capa-consulta-grafo-kuzu-bitemporalidad-nl-v2.md` (Kuzu/bitemporalidad)
-- `docs/adr/ADR-051-v2.2-final-seed-parity-gate-correlation-health.md` (parity gate)
-- `correlation-engine/include/correlation_engine/flow_uid.hpp` (encoding canónico, `compute_flow_uid`, `window_micros`)
-- `correlation-engine/include/correlation_engine/cypher_builder.hpp` (MERGE, ON CREATE SET; prod=`$param`, logging=interpolado)
-- `correlation-engine/include/correlation_engine/correlation_record.hpp` (struct 19 cols; sec=int64, nano=int32, src/dst_port=uint32)
-- `correlation-engine/src/correlation_reader.cpp:67` (`parse_and_verify`; from_chars + parse_double; descarta nullopt)
-- `correlation-engine/src/main.cpp` (Camino 0: ifstream→parse_and_verify→flow_uid→IGraphSink; `--follow` tail-poll roto en rotación)
-- `correlation-engine/schema/schema.cypher` (NetworkFlow PK=flow_uid simple; Alert/TelemetryEvent PK=event_id; veredicto desnormalizado cols 12-17)
-- `ml-detector/src/config_loader.cpp:455` (patrón csv_writer a calcar para bronze config JSON)
-- `scripts/parquet/` (RAG-127, Ed25519, capa DISTINTA — no tocar para el circuito)
+## Deudas cerradas DAY 203
+- `DEBT-CONFIG-BRONZE-HARDCODE-001` (P0) — CERRADA (DAY 201 + DAY 202, writer + reader).
+- `DEBT-CIRCUIT-BRONZE-ROTATION-FOLLOW-001` (P0) — CERRADA (DAY 203, segmentación + watcher).
+
+## Deudas abiertas nuevas DAY 203
+- `DEBT-CORRELATION-ROUNDTRIP-ORPHANED-001` (P1) — `test_correlation_roundtrip.cpp` sin `add_test`, laguna preexistente expuesta hoy.
+- (nota, no formal aún) higiene `/vagrant/logs/correlation/argus` — basura de sesiones anteriores al patrón segmentado.
+- (nota, no formal aún) posible `make emecas+++` — gate E2E río-abajo, ver acción 3.
 
 ## Rama
-`day196/circuit-adapters-zmq` (al día con main vía fast-forward, trae la higiene). ADR-058 commiteado (`47d0a8d6`). Pendiente push. El Eslabón 0 va en el mismo PR que el ADR (commit de doc no pasa gate, va con la implementación). day194 cerrada (PR #107). Backup del ADR-058 en `~/adr058-backup.md` (host, 315 líneas) por si acaso.
+`main`, al día (`6808e847`). Sin rama de trabajo abierta — DAY 204 empieza limpio.
 
+## Punteros
+- `ml-detector/include/correlation_writer.hpp` + `.cpp` — segmentación, `finalize_segment_locked()`, rename atómico.
+- `correlation-engine/include/correlation_engine/bronze_dir_watcher.hpp` + `.cpp` — watcher inotify nuevo.
+- `correlation-engine/src/main.cpp` — modo directorio vs modo legacy, `process_segment()` compartido.
+- `ml-detector/tests/integration/test_correlation_roundtrip.cpp` — existe, huérfano, objetivo DAY 204 acción 2.
+- `docs/BACKLOG.md` — `DEBT-CORRELATION-ROUNDTRIP-ORPHANED-001` recién añadida.
+
+*Via Appia Quality — Un escudo que aprende de su propia sombra.*

--- a/ml-detector/include/correlation_writer.hpp
+++ b/ml-detector/include/correlation_writer.hpp
@@ -73,7 +73,8 @@ public:
         uint64_t records_written;
         uint64_t records_skipped;   // community_id vacío
         uint64_t rows_failed;
-        std::string current_file;
+        std::string current_file;        // .tmp del segmento actualmente abierto (DAY 203)
+        std::string current_final_path;  // path final post-rename (DAY 204, DEBT-CORRELATION-ROUNDTRIP-ORPHANED-001)
     };
     Stats get_stats() const noexcept;
 

--- a/ml-detector/src/correlation_writer.cpp
+++ b/ml-detector/src/correlation_writer.cpp
@@ -159,7 +159,7 @@ void CorrelationWriter::flush() {
 
 CorrelationWriter::Stats CorrelationWriter::get_stats() const noexcept {
     return Stats{ records_written_.load(), records_skipped_.load(),
-                 rows_failed_.load(), current_tmp_path_ };
+                 rows_failed_.load(), current_tmp_path_, current_final_path_ };
 }
 
 // ----------------------------------------------------------------------------

--- a/ml-detector/tests/integration/test_correlation_roundtrip.cpp
+++ b/ml-detector/tests/integration/test_correlation_roundtrip.cpp
@@ -92,7 +92,7 @@ TEST(CorrelationRoundTrip, WriterToReader) {
         ml_defender::CorrelationWriter writer(cfg, logger);
         ASSERT_TRUE(writer.write_record(event));
         writer.flush();
-        written_path = writer.get_stats().current_file;
+        written_path = writer.get_stats().current_final_path;
     }
     ASSERT_FALSE(written_path.empty());
     ASSERT_TRUE(fs::exists(written_path));
@@ -174,7 +174,7 @@ TEST(CorrelationRoundtrip, QuotedCommaFieldsSurviveRoundTrip) {
         ml_defender::CorrelationWriter writer(cfg, logger);
         ASSERT_TRUE(writer.write_record(event));
         writer.flush();
-        written_path = writer.get_stats().current_file;
+        written_path = writer.get_stats().current_final_path;
     }
     ASSERT_FALSE(written_path.empty());
     ASSERT_TRUE(fs::exists(written_path));
@@ -246,7 +246,7 @@ TEST(CorrelationRoundTrip, QuotedCommaFieldSurvivesRoundTrip) {
         ml_defender::CorrelationWriter writer(cfg, logger);
         ASSERT_TRUE(writer.write_record(event));
         writer.flush();
-        written_path = writer.get_stats().current_file;
+        written_path = writer.get_stats().current_final_path;
     }
     ASSERT_FALSE(written_path.empty());
     ASSERT_TRUE(fs::exists(written_path));
@@ -315,7 +315,7 @@ TEST(CorrelationRoundTrip, EscapedQuoteFieldSurvivesRoundTrip) {
         ml_defender::CorrelationWriter writer(cfg, logger);
         ASSERT_TRUE(writer.write_record(event));
         writer.flush();
-        written_path = writer.get_stats().current_file;
+        written_path = writer.get_stats().current_final_path;
     }
     ASSERT_FALSE(written_path.empty());
 

--- a/test_correlation_roundtrip.sh
+++ b/test_correlation_roundtrip.sh
@@ -1,0 +1,86 @@
+cat << 'EOF'
+=== Desde el host, en test-zeromq-docker, rama main al día (6808e847) ===
+
+git checkout -b day204/close-roundtrip-orphaned
+
+git add ml-detector/include/correlation_writer.hpp \
+        ml-detector/src/correlation_writer.cpp \
+        ml-detector/tests/integration/test_correlation_roundtrip.cpp
+
+git status
+# (verificar que solo estos 3 ficheros entran, nada mas)
+
+git commit -m "fix(correlation_writer): Stats::current_final_path — cierra DEBT-CORRELATION-ROUNDTRIP-ORPHANED-001
+
+get_stats().current_file devolvia current_tmp_path_ (el .csv.tmp abierto
+ahora mismo), no el path final post-rename. test_correlation_roundtrip
+capturaba ese valor mientras el writer seguia vivo; al destruirse, el
+propio finalize_segment_locked() renombraba el .tmp -> .csv, dejando el
+path capturado inexistente. No era un bug del rename (que funciona bien,
+verificado en EMECAS++ DAY 203) sino un campo de observabilidad que no
+distinguia 'segmento en curso' de 'segmento cerrado y legible'.
+
+Fix quirurgico:
+- Stats: nuevo campo current_final_path junto a current_file (que
+  mantiene su semantica: tmp del segmento actualmente abierto).
+- get_stats() puebla current_final_path con current_final_path_.
+- test_correlation_roundtrip.cpp: los 4 tests leen current_final_path
+  en vez de current_file para verificar el segmento cerrado.
+
+Causa raiz confirmada por eliminacion, no supuesta:
+1) add_test SI estaba presente en tests/CMakeLists.txt (contra lo que
+   registraba la nota DAY203) -- el build dir de la VM tenia cache de
+   CMake sin reconfigurar desde que se añadio el bloque.
+2) Tras reconfigurar (rm CMakeCache.txt+CMakeFiles && cmake ..), el
+   target compilaba y ctest lo listaba, pero las 4 pruebas fallaban RED
+   contra el bronce segmentado -- ese RED es el que este commit corrige.
+
+EMECAS++: test_correlation_roundtrip 4/4 PASSED (ctest -R, VM defender).
+
+Authors: Alonso Isidoro Roman + Claude (Anthropic)"
+
+git push -u origin day204/close-roundtrip-orquést...
+EOF
+Salida
+
+=== Desde el host, en test-zeromq-docker, rama main al día (6808e847) ===
+
+git checkout -b day204/close-roundtrip-orphaned
+
+git add ml-detector/include/correlation_writer.hpp \
+        ml-detector/src/correlation_writer.cpp \
+        ml-detector/tests/integration/test_correlation_roundtrip.cpp
+
+git status
+# (verificar que solo estos 3 ficheros entran, nada mas)
+
+git commit -m "fix(correlation_writer): Stats::current_final_path — cierra DEBT-CORRELATION-ROUNDTRIP-ORPHANED-001
+
+get_stats().current_file devolvia current_tmp_path_ (el .csv.tmp abierto
+ahora mismo), no el path final post-rename. test_correlation_roundtrip
+capturaba ese valor mientras el writer seguia vivo; al destruirse, el
+propio finalize_segment_locked() renombraba el .tmp -> .csv, dejando el
+path capturado inexistente. No era un bug del rename (que funciona bien,
+verificado en EMECAS++ DAY 203) sino un campo de observabilidad que no
+distinguia 'segmento en curso' de 'segmento cerrado y legible'.
+
+Fix quirurgico:
+- Stats: nuevo campo current_final_path junto a current_file (que
+  mantiene su semantica: tmp del segmento actualmente abierto).
+- get_stats() puebla current_final_path con current_final_path_.
+- test_correlation_roundtrip.cpp: los 4 tests leen current_final_path
+  en vez de current_file para verificar el segmento cerrado.
+
+Causa raiz confirmada por eliminacion, no supuesta:
+1) add_test SI estaba presente en tests/CMakeLists.txt (contra lo que
+   registraba la nota DAY203) -- el build dir de la VM tenia cache de
+   CMake sin reconfigurar desde que se añadio el bloque.
+2) Tras reconfigurar (rm CMakeCache.txt+CMakeFiles && cmake ..), el
+   target compilaba y ctest lo listaba, pero las 4 pruebas fallaban RED
+   contra el bronce segmentado -- ese RED es el que este commit corrige.
+
+EMECAS++: test_correlation_roundtrip 4/4 PASSED (ctest -R, VM defender).
+
+Authors: Alonso Isidoro Roman + Claude (Anthropic)"
+
+git push -u origin day204/close-roundtrip-orquést...


### PR DESCRIPTION
…ELATION-ROUNDTRIP-ORPHANED-001

get_stats().current_file devolvia current_tmp_path_ (el .csv.tmp abierto ahora mismo), no el path final post-rename. test_correlation_roundtrip capturaba ese valor mientras el writer seguia vivo; al destruirse, el propio finalize_segment_locked() renombraba el .tmp -> .csv, dejando el path capturado inexistente. No era un bug del rename (que funciona bien, verificado en EMECAS++ DAY 203) sino un campo de observabilidad que no distinguia 'segmento en curso' de 'segmento cerrado y legible'.

Fix quirurgico:
- Stats: nuevo campo current_final_path junto a current_file (que mantiene su semantica: tmp del segmento actualmente abierto).
- get_stats() puebla current_final_path con current_final_path_.
- test_correlation_roundtrip.cpp: los 4 tests leen current_final_path en vez de current_file para verificar el segmento cerrado.

Causa raiz confirmada por eliminacion, no supuesta: 1) add_test SI estaba presente en tests/CMakeLists.txt (contra lo que
   registraba la nota DAY203) -- el build dir de la VM tenia cache de
   CMake sin reconfigurar desde que se añadio el bloque.
2) Tras reconfigurar (rm CMakeCache.txt+CMakeFiles && cmake ..), el
   target compilaba y ctest lo listaba, pero las 4 pruebas fallaban RED
   contra el bronce segmentado -- ese RED es el que este commit corrige.

EMECAS++: test_correlation_roundtrip 4/4 PASSED (ctest -R, VM defender).

Authors: Alonso Isidoro Roman + Claude (Anthropic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed correlation round-trip verification so tests read the completed output file instead of the temporary in-progress file.
  - Improved reporting of the current output path, making segment status clearer and more accurate.

- **Tests**
  - Updated integration coverage for round-trip CSV cases to match the finalized file path.
  - Added a reproducible shell test covering the correlation writer round-trip flow.

- **Documentation**
  - Refreshed continuity notes and updated current project status and action items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->