### PR TITLE
feat(correlation-engine): emecas+++ — test de circuito completo bronc…

### DIFF
--- a/correlation-engine/CMakeLists.txt
+++ b/correlation-engine/CMakeLists.txt
@@ -43,7 +43,8 @@ add_library(correlation_engine STATIC
         src/logging_graph_sink.cpp
         src/kuzu_graph_sink.cpp
         src/config_loader.cpp
-        src/bronze_dir_watcher.cpp)
+        src/bronze_dir_watcher.cpp
+        src/segment_processor.cpp)
 target_include_directories(correlation_engine PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(correlation_engine PUBLIC ${LIBSODIUM_INCLUDE_DIRS})
 target_include_directories(correlation_engine PRIVATE ${KUZU_INC})  # solo el .cpp incluye kuzu.hpp
@@ -108,3 +109,31 @@ find_package(Threads REQUIRED)
 add_executable(kuzu_concurrency_smoke experiments/kuzu_concurrency_smoke.cpp)
 target_include_directories(kuzu_concurrency_smoke PRIVATE ${KUZU_INC})
 target_link_libraries(kuzu_concurrency_smoke PRIVATE correlation_engine Threads::Threads)
+
+# ── DAY 204 — emecas+++: circuito completo bronce->Kuzu, un solo proceso, FS puro ──
+# ADR-058 §1: inyectar evento sintetico -> verificar HMAC en bronce -> verificar
+# MATCH en Kuzu. Cruza a ml-detector (CorrelationWriter real), mismo patron que
+# ml-detector/tests/test_correlation_roundtrip.cpp usa en sentido inverso.
+find_package(Protobuf REQUIRED)
+find_library(CORRELATION_V1_LIB NAMES correlation_v1 PATHS /usr/local/lib REQUIRED)
+
+add_executable(test_bronze_to_kuzu_circuit
+        tests/test_bronze_to_kuzu_circuit.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../ml-detector/src/correlation_writer.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../protobuf/network_security.pb.cc)
+target_include_directories(test_bronze_to_kuzu_circuit PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../ml-detector/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../protobuf
+        ${KUZU_INC}
+        /usr/local/include)
+target_link_libraries(test_bronze_to_kuzu_circuit PRIVATE
+        correlation_engine
+        ${CORRELATION_V1_LIB}
+        ${Protobuf_LIBRARIES}
+        spdlog::spdlog
+        OpenSSL::SSL
+        OpenSSL::Crypto
+        GTest::gtest_main)
+target_compile_definitions(test_bronze_to_kuzu_circuit PRIVATE
+        SCHEMA_PATH="${CMAKE_CURRENT_SOURCE_DIR}/schema/schema.cypher")
+add_test(NAME test_bronze_to_kuzu_circuit COMMAND test_bronze_to_kuzu_circuit)

--- a/correlation-engine/include/correlation_engine/segment_processor.hpp
+++ b/correlation-engine/include/correlation_engine/segment_processor.hpp
@@ -1,0 +1,25 @@
+#pragma once
+// correlation-engine/include/correlation_engine/segment_processor.hpp
+// DAY 204 — extraido de main.cpp (antes lambda inline) para que produccion
+// y los tests de circuito completo (emecas+++, DEBT-EMECAS-PLUS-PLUS)
+// ejerzan EXACTAMENTE el mismo codigo. Cero reimplementacion, cero deriva.
+#include <string>
+#include <vector>
+#include <cstdint>
+#include "correlation_engine/i_graph_sink.hpp"
+
+namespace argus::correlation {
+
+struct SegmentProcessResult {
+    uint64_t total;
+    uint64_t discarded;
+};
+
+// Lee un segmento bronce COMPLETO (fichero .csv inmutable, DAY 203) linea a
+// linea: parse_and_verify -> flow_uid -> sink.write. Devuelve contadores del
+// segmento (el llamador decide si acumula globales, como hace main()).
+SegmentProcessResult process_segment(const std::string& path,
+                                      const std::vector<uint8_t>& hmac_key,
+                                      IGraphSink& sink);
+
+} // namespace argus::correlation

--- a/correlation-engine/src/main.cpp
+++ b/correlation-engine/src/main.cpp
@@ -21,6 +21,7 @@
 #include "correlation_engine/kuzu_graph_sink.hpp"
 #include "correlation_engine/config_loader.hpp"
 #include "correlation_engine/bronze_dir_watcher.hpp"
+#include "correlation_engine/segment_processor.hpp"
 #include <ctime>
 #include <filesystem>
 #include <algorithm>
@@ -105,29 +106,14 @@ int main(int argc, char* argv[]) {
 
     uint64_t total = 0, discarded = 0;
 
-    // Segmento completo (bronce inmutable, DAY 203) -> se lee entero, sin
-    // offset. Compartido por el modo directorio (replay + callback del watcher).
-    auto process_segment = [&](const std::string& path) {
-        std::ifstream in(path);
-        if (!in) {
-            spdlog::warn("[CONSUMER] no se puede abrir segmento: {}", path);
-            return;
-        }
-        std::string line;
-        uint64_t seg_total = 0, seg_discarded = 0;
-        while (std::getline(in, line)) {
-            if (line.empty()) continue;
-            auto rec = ac::parse_and_verify(line, hmac_key);
-            if (!rec) { ++seg_discarded; continue; }
-            const uint64_t window = ac::window_micros(rec->flow_start_sec, rec->flow_start_nano);
-            const std::string fuid = ac::compute_flow_uid(rec->node_id, rec->community_id, window);
-            sink->write(*rec, fuid);
-            ++seg_total;
-        }
-        total += seg_total;
-        discarded += seg_discarded;
-        spdlog::info("[CONSUMER] segmento {}: {} materializados, {} descartados",
-                     path, seg_total, seg_discarded);
+    // DAY 204: la logica de parseo/verificacion/sink vive en process_segment
+    // (correlation_engine, libreria compartida) -- mismo codigo que ejercen
+    // los tests de circuito completo (emecas+++). Este wrapper solo acumula
+    // los contadores locales de main().
+    auto handle_segment = [&](const std::string& path) {
+        auto r = ac::process_segment(path, hmac_key, *sink);
+        total += r.total;
+        discarded += r.discarded;
     };
 
     if (!bronze_path.empty()) {
@@ -191,12 +177,12 @@ int main(int argc, char* argv[]) {
             }
             std::sort(existing.begin(), existing.end());
         }
-        for (const auto& path : existing) process_segment(path);
+        for (const auto& path : existing) handle_segment(path);
 
         if (follow) {
             spdlog::info("[CONSUMER] --follow: vigilando {} (inotify IN_MOVED_TO, Ctrl-C para salir)",
                         root_dir);
-            ac::BronzeDirWatcher watcher(root_dir, process_segment);
+            ac::BronzeDirWatcher watcher(root_dir, handle_segment);
             watcher.run();  // bloqueante
         }
     }

--- a/correlation-engine/src/segment_processor.cpp
+++ b/correlation-engine/src/segment_processor.cpp
@@ -1,0 +1,35 @@
+// correlation-engine/src/segment_processor.cpp — DAY 204
+#include "correlation_engine/segment_processor.hpp"
+#include "correlation_engine/correlation_reader.hpp"
+#include "correlation_engine/flow_uid.hpp"
+
+#include <fstream>
+#include <spdlog/spdlog.h>
+
+namespace argus::correlation {
+
+SegmentProcessResult process_segment(const std::string& path,
+                                      const std::vector<uint8_t>& hmac_key,
+                                      IGraphSink& sink) {
+    std::ifstream in(path);
+    if (!in) {
+        spdlog::warn("[CONSUMER] no se puede abrir segmento: {}", path);
+        return {0, 0};
+    }
+    std::string line;
+    uint64_t seg_total = 0, seg_discarded = 0;
+    while (std::getline(in, line)) {
+        if (line.empty()) continue;
+        auto rec = parse_and_verify(line, hmac_key);
+        if (!rec) { ++seg_discarded; continue; }
+        const uint64_t window = window_micros(rec->flow_start_sec, rec->flow_start_nano);
+        const std::string fuid = compute_flow_uid(rec->node_id, rec->community_id, window);
+        sink.write(*rec, fuid);
+        ++seg_total;
+    }
+    spdlog::info("[CONSUMER] segmento {}: {} materializados, {} descartados",
+                 path, seg_total, seg_discarded);
+    return {seg_total, seg_discarded};
+}
+
+} // namespace argus::correlation

--- a/correlation-engine/tests/test_bronze_to_kuzu_circuit.cpp
+++ b/correlation-engine/tests/test_bronze_to_kuzu_circuit.cpp
@@ -1,0 +1,200 @@
+// test_bronze_to_kuzu_circuit.cpp — DAY 204, emecas+++ (circuito completo FS).
+// ADR-058 §1: inyectar evento sintetico -> verificar HMAC en bronce -> verificar
+// MATCH en Kuzu. Un solo proceso, filesystem puro (sin ZMQ -- ese tramo aun no
+// existe, Eslabon 1+). Reutiliza produccion real en cada eslabon:
+//   CorrelationWriter (ml-detector, real)          -> escribe bronce segmentado
+//   ac::process_segment (correlation-engine, real) -> parse_and_verify + sink
+//   KuzuGraphSink (correlation-engine, real)       -> materializa en Kuzu
+// Cero reimplementacion: si produccion cambia, este test se entera.
+// Authors: Alonso Isidoro Roman + Claude (Anthropic)
+#include <gtest/gtest.h>
+
+#include "correlation_writer.hpp"
+#include "correlation_engine/segment_processor.hpp"
+#include "correlation_engine/kuzu_graph_sink.hpp"
+
+#include <network_security.pb.h>
+#include <google/protobuf/timestamp.pb.h>
+
+#include <kuzu.hpp>
+
+#include <spdlog/spdlog.h>
+#include <spdlog/sinks/null_sink.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <cstdint>
+#include <cstdio>
+#include <memory>
+
+namespace fs = std::filesystem;
+using namespace argus::correlation;
+
+namespace {
+
+#ifndef SCHEMA_PATH
+#  error "SCHEMA_PATH no definido (ver CMakeLists: target_compile_definitions)"
+#endif
+
+const std::string KEY_HEX =
+"abababababababababababababababababababababababababababababababab";
+
+std::vector<uint8_t> hex_to_bytes(const std::string& hex) {
+std::vector<uint8_t> out;
+out.reserve(hex.size() / 2);
+for (size_t i = 0; i < hex.size(); i += 2) {
+unsigned int b;
+std::sscanf(hex.c_str() + i, "%02x", &b);
+out.push_back(static_cast<uint8_t>(b));
+}
+return out;
+}
+
+std::shared_ptr<spdlog::logger> null_logger(const std::string& name) {
+return std::make_shared<spdlog::logger>(
+name, std::make_shared<spdlog::sinks::null_sink_mt>());
+}
+
+protobuf::NetworkSecurityEvent make_event(const std::string& event_id,
+const std::string& community_id,
+const std::string& classification) {
+protobuf::NetworkSecurityEvent event;
+event.set_event_id(event_id);
+event.set_originating_node_id("node-emecas-plus-plus");
+event.set_final_classification(classification);
+event.set_threat_category("RANSOMWARE");
+event.set_fast_detector_score(0.91);
+event.set_ml_detector_score(0.97);
+event.set_overall_threat_score(0.95);
+event.set_authoritative_source(::protobuf::DETECTOR_SOURCE_ML_PRIORITY);
+auto* nf = event.mutable_network_features();
+nf->set_community_id(community_id);
+nf->set_source_ip("10.10.10.10");
+nf->set_destination_ip("10.10.10.20");
+nf->set_source_port(4444u);
+nf->set_destination_port(443u);
+nf->set_protocol_name("tcp");
+nf->mutable_flow_start_time()->set_seconds(1717480800);
+nf->mutable_flow_start_time()->set_nanos(123456000);
+return event;
+}
+
+int64_t count_query(kuzu::main::Connection& c, const std::string& q) {
+auto r = c.query(q);
+if (!r->isSuccess() || !r->hasNext()) return -1;
+return std::stoll(r->getNext()->toString());
+}
+
+}  // namespace
+
+// ── Circuito completo, camino feliz: bronce -> Kuzu MATCH ────────────────────
+TEST(EmecasPlusPlus, BronzeToKuzuCircuitHappyPath) {
+const auto hmac_key = hex_to_bytes(KEY_HEX);
+
+    // 1. Escribe con el CorrelationWriter REAL (ml-detector).
+    const std::string base = (fs::temp_directory_path() /
+        ("emecas_ppp_" + std::to_string(::getpid()))).string();
+    fs::remove_all(base);
+
+    ml_defender::CorrelationWriterConfig cfg;
+    cfg.base_dir     = base;
+    cfg.hmac_key_hex = KEY_HEX;
+
+    std::string final_path;
+    {
+        ml_defender::CorrelationWriter writer(cfg, null_logger("emecas-writer"));
+        auto event = make_event("evt-emecas-001", "1:emecasCircuit==", "MALICIOUS");
+        ASSERT_TRUE(writer.write_record(event));
+        writer.flush();
+        final_path = writer.get_stats().current_final_path;
+    }  // destructor: finalize_segment_locked() -> rename atomico .tmp -> .csv
+    ASSERT_FALSE(final_path.empty());
+    ASSERT_TRUE(fs::exists(final_path));
+
+    // 2. Lee con process_segment REAL (correlation-engine, produccion).
+    const std::string db_path = "/tmp/test_emecas_ppp_happy.kuzu";
+    std::remove(db_path.c_str());
+    {
+        KuzuGraphSink sink(db_path, SCHEMA_PATH, null_logger("emecas-sink"));
+        auto result = process_segment(final_path, hmac_key, sink);
+        EXPECT_EQ(result.total, 1u);
+        EXPECT_EQ(result.discarded, 0u);
+        const auto fr = sink.flush();
+        EXPECT_TRUE(fr);
+        EXPECT_EQ(fr.rows_flushed, 1u);
+    }
+
+    // 3. Verifica MATCH en Kuzu (ADR-058 §1). El HMAC en bronce ya lo
+    //    garantiza parse_and_verify dentro de process_segment (test siguiente).
+    kuzu::main::SystemConfig db_cfg;
+    auto db   = std::make_unique<kuzu::main::Database>(db_path, db_cfg);
+    auto conn = std::make_unique<kuzu::main::Connection>(db.get());
+    EXPECT_EQ(count_query(*conn, "MATCH (f:NetworkFlow) RETURN count(*)"), 1);
+    EXPECT_EQ(count_query(*conn, "MATCH (a:Alert) RETURN count(*)"), 1);
+    EXPECT_EQ(count_query(*conn,
+        "MATCH (:Alert)-[:ALERT_ABOUT]->(:NetworkFlow) RETURN count(*)"), 1);
+
+    fs::remove_all(base);
+    std::remove(db_path.c_str());
+}
+
+// ── Circuito completo, fila manipulada: descartada ANTES de Kuzu ─────────────
+// Cierra ADR-058 §1 desde el otro lado: si el HMAC no verifica, el evento NUNCA
+// llega al grafo -- ni un nodo NetworkFlow huerfano, ni una fila fantasma.
+TEST(EmecasPlusPlus, TamperedRowNeverReachesKuzu) {
+const auto hmac_key = hex_to_bytes(KEY_HEX);
+
+    const std::string base = (fs::temp_directory_path() /
+        ("emecas_ppp_tamper_" + std::to_string(::getpid()))).string();
+    fs::remove_all(base);
+
+    ml_defender::CorrelationWriterConfig cfg;
+    cfg.base_dir     = base;
+    cfg.hmac_key_hex = KEY_HEX;
+
+    std::string final_path;
+    {
+        ml_defender::CorrelationWriter writer(cfg, null_logger("emecas-writer-tamper"));
+        auto event = make_event("evt-emecas-tamper", "1:emecasTamper==", "MALICIOUS");
+        ASSERT_TRUE(writer.write_record(event));
+        writer.flush();
+        final_path = writer.get_stats().current_final_path;
+    }
+    ASSERT_TRUE(fs::exists(final_path));
+
+    // Manipula el segmento YA CERRADO (simula bit-flip en transito/disco):
+    // altera final_classification sin recalcular el HMAC -> debe rechazarse.
+    {
+        std::ifstream in(final_path);
+        std::string line;
+        std::getline(in, line);
+        in.close();
+        auto pos = line.find("MALICIOUS");
+        ASSERT_NE(pos, std::string::npos);
+        line.replace(pos, 9, "BENIGN!!!");  // misma longitud, HMAC ya no cuadra
+        std::ofstream out(final_path, std::ios::trunc);
+        out << line << "\n";
+    }
+
+    const std::string db_path = "/tmp/test_emecas_ppp_tamper.kuzu";
+    std::remove(db_path.c_str());
+    {
+        KuzuGraphSink sink(db_path, SCHEMA_PATH, null_logger("emecas-sink-tamper"));
+        auto result = process_segment(final_path, hmac_key, sink);
+        EXPECT_EQ(result.total, 0u);
+        EXPECT_EQ(result.discarded, 1u);
+        const auto fr = sink.flush();
+        EXPECT_TRUE(fr);
+        EXPECT_EQ(fr.rows_flushed, 0u);
+    }
+
+    kuzu::main::SystemConfig db_cfg;
+    auto db   = std::make_unique<kuzu::main::Database>(db_path, db_cfg);
+    auto conn = std::make_unique<kuzu::main::Connection>(db.get());
+    EXPECT_EQ(count_query(*conn, "MATCH (f:NetworkFlow) RETURN count(*)"), 0);
+
+    fs::remove_all(base);
+    std::remove(db_path.c_str());
+}


### PR DESCRIPTION
…e->Kuzu (ADR-058 §1)

Cierra la nota informal DEBT-EMECAS-PLUS-PLUS dejada en DAY 203: EMECAS/ EMECAS++ validan 'compila y pasan los tests de cada componente' pero no 'fluye el dato extremo a extremo por el rio'. Este test si lo hace, en un solo proceso, filesystem puro (sin ZMQ -- ese tramo es Eslabon 1+):

CorrelationWriter (ml-detector, real) -> bronce segmentado (.tmp->rename) process_segment (correlation-engine, real) -> parse_and_verify + flow_uid KuzuGraphSink (correlation-engine, real) -> materializa en grafo MATCH Cypher -> verifica NetworkFlow + Alert + ALERT_ABOUT

Refactor previo (DAY 204, requisito para que el test comparta codigo con produccion en vez de reimplementarlo -- ya nos mordio hoy con el roundtrip de la mañana):
- process_segment extraida de main.cpp (antes lambda inline) a correlation_engine/segment_processor.{hpp,cpp}, añadida a la lib STATIC correlation_engine. main.cpp pasa a llamarla via un wrapper fino (handle_segment) que solo acumula contadores locales -- cero cambio de comportamiento, mismo codigo ejercido por produccion y por el test nuevo.

Dos casos:
- BronzeToKuzuCircuitHappyPath: evento MALICIOUS real -> 1 NetworkFlow, 1 Alert, 1 ALERT_ABOUT en Kuzu tras flush().
- TamperedRowNeverReachesKuzu: fila con HMAC roto (bit-flip post-cierre, simulando corrupcion en transito/disco) -> descartada antes del sink, grafo permanece vacio. Cierra ADR-058 §1 desde el lado adverso.

CMake: cruza a ml-detector (CorrelationWriter + protobuf central de /vagrant/protobuf/, mismo .pb.cc que usan todos los componentes via 'make proto') igual que ml-detector/tests/test_correlation_roundtrip.cpp cruza en sentido inverso -- mismo patron ya establecido en el repo, sin arbol de CMake compartido.

EMECAS: correlation-engine 7/7 PASSED (6 preexistentes sin regresion + 2 nuevos). Entra automaticamente en 'make test-components'/'test-all' (ya dependia de correlation-engine-test).

Authors: Alonso Isidoro Roman + Claude (Anthropic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared segment processing so CSV segments can be verified and written through a common flow.
  * Added a new end-to-end integration test that exercises the full bronze-to-database path.
  * Expanded the build to compile the new segment processing component and test target.

* **Bug Fixes**
  * Improved handling of segment processing in directory mode by reusing the shared logic for discovered files.
  * Added coverage for tampered records to ensure invalid data is rejected before reaching the database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->