### PR TITLE
DAY 233 — MITRE -> grafo, correlacion cross-sensor (docs + mitre_start skeleton)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -5486,3 +5486,75 @@ esté en el Vagrantfile, un `vagrant destroy` lo pierde.
 
 **Familia.** `DEBT-PROVISION-SED-SILENT-NOOP-001` y la deuda del restart de
 Suricata: provisioning que no verifica el resultado real.
+
+## DEBT-EVENT-ID-COLLISION-001 — el event_id de aRGus colisiona bajo carga
+- **Severidad:** P2 (data-quality; NO afecta a la correlación, que va por community_id)
+- **Medido (DAY 233):** 2.625 filas de bronce de aRGus (ventana nmap -A) →
+  solo 1.522 nodos TelemetryEvent en Kuzu. El MERGE del evento es por event_id
+  y funde los que colisionan.
+- **Causa:** event_id = to_string(timestamp) + "_" + to_string(src_ip ^ dst_ip)
+  (ring_consumer.cpp:854-855). Bajo un scan, muchos flujos comparten el mismo
+  segundo de timestamp Y el mismo XOR de IPs (mismo par src/dst, distinto puerto)
+  → mismo event_id.
+- **Impacto:** subcontaje de observaciones por sensor; puede fundir dos alertas
+  distintas del mismo par en un nodo. No corrompe el join (community_id es la clave).
+- **Arreglo candidato:** incluir el puerto (o un discriminador de flujo) en el
+  event_id. El event_id de Suricata (base64(BLAKE2b) determinista) NO colisiona así;
+  converger hacia ese estilo.
+
+## DEBT-FLOWUID-WINDOW-BUCKET-001 — window sin bucketizar infla nodos y aristas
+- **Severidad:** P2 (cardinalidad; la correlación es válida pero sobre-representada)
+- **Medido (DAY 233):** 44 community_id corroborados cross-sensor → 253 aristas
+  CORRELATES_FLOW. El factor ~6× es porque cada sensor materializa una misma
+  conversación como varios NetworkFlow.
+- **Causa:** flow_uid = hash(node_id ‖ community_id ‖ flow_start_window ‖ seq),
+  con window_micros = sec*1e6 + nanos/1e3 — precisión de MICROSEGUNDO, sin el
+  floor(flow_start_epoch/N) que manda ADR-052 §3.1.4 (default 60s) + seq_in_window
+  (hoy siempre 0, DEBT-FLOWUID-SEQ-COLLISION-001).
+- **Impacto:** una conversación única = N nodos; el self-join los empareja todos.
+  El recuento "por community_id" (44) es el honesto; el "por arista" (253) está inflado.
+- **Arreglo candidato:** bucketing de §3.1.4 + seq_in_window transportado. LIGADO a
+  DEBT-FLOWSTART-CLOCK-DOMAIN-001 y a node_id por-sensor (§3.1.2): arreglar el reloj
+  sin dar node_id propio a cada sensor fundiría los nodos cross-sensor. Orden:
+  node_id-distinto y bucket JUNTOS, nunca el reloj solo.
+
+## DEBT-DOWNSTREAM-TO-GRAPH-NOT-AUTOMATED-001 — el camino telemetría→grafo es 100% manual
+- **Severidad:** P1 (bloquea el criterio de cierre: "todos los datos generables por Makefile")
+- **Medido (DAY 233):** el recorrido completo del dato adversarial al grafo se
+  ejecutó a mano, comando a comando: disparo MITRE (nmap -A desde client) →
+  suricata-adapter (eve.json→bronce) → bronze_to_gold_converter ×2 (aRGus y
+  Suricata, CSV→avro→parquet) → parquet_to_kuzu_loader ×2 (misma BD) →
+  poblador CORRELATES_FLOW (kuzu_query) → consultas de verificación.
+- **Contraste:** el pipeline de RUNTIME (sniffer→ml-detector→firewall) SÍ está
+  automatizado en pipeline-start; el downstream offline NO tiene ninguna tarea.
+- **Impacto:** el resultado central del paper (44 flujos corroborados cross-sensor)
+  hoy NO es reproducible por un tercero desde el repo — es anecdótico hasta que
+  exista el target.
+- **Arreglo (trabajo de DAY 234):** dos tareas y solo dos deben bastar —
+  `pipeline-start` (levanta TODO, incluso exporta la clave del bronce al entorno)
+  y `mitre-start` (dispara el ataque y arrastra adapters→converters→loaders→
+  poblador→consultas). Registrar como criterio: cero comandos manuales entre
+  "stack arriba" y "aristas cross-sensor en el grafo".
+- **Nota:** el disparo MITRE se dejó manual A PROPÓSITO en DAY 233 porque el
+  objetivo era AVERIGUAR qué técnica hace reaccionar a cada sensor (medido:
+  nmap -A sí, nmap -sS no, hydra no llega a atacar por ssh key-only). Esa
+  incógnita ya está resuelta → mitre-start puede fijar nmap -A como disparo canónico.
+
+## DEBT-HMAC-KEY-INSECURE-TRANSPORT-001 — la clave de cifrado se sirve por GET HTTP en claro
+- **Severidad:** P1 de seguridad (JAMÁS debe llegar a producción)
+- **Medido (DAY 233):** el converter offline necesita ARGUS_BRONZE_HMAC_KEY_HEX y
+  hay que sacarla a mano con `curl -s http://localhost:2379/secrets/ml-detector`
+  → la clave HMAC de 64 hex viaja en TEXTO PLANO por un GET sin TLS ni auth. El
+  ml-detector la obtiene por el mismo mecanismo (get_hmac_key → http::get al REST
+  del etcd-server), no por Vault directo.
+- **Agujero:** clave de cifrado expuesta en claro sobre la red, sin TLS, sin
+  autenticación, accesible por cualquiera que alcance :2379. Tolerable SOLO en
+  fase de construcción del laboratorio.
+- **Doble fuente de verdad (DEBT-BRONZE-KEY-PROVISIONING-001, relacionada):** el
+  firmante (ml-detector) está integrado con el almacén; el converter offline lee
+  del entorno y NADIE lo cableó al almacén → por eso la extracción manual.
+- **Arreglo (declarado explícitamente como NO-NUESTRO):** los componentes Y el
+  converter deben ir DIRECTOS a Vault usando sus capacidades nativas (auth por
+  token/AppRole, TLS, leases, secretos dinámicos), eliminando el REST plano
+  intermedio. Es una de las PRIMERAS cosas a afrontar por quien mantenga el
+  pipeline, junto con la creación de los modelos del ml-detector y el fast-path.

--- a/docs/continuity/PROMPT_CONTINUE_CLAUDE.md
+++ b/docs/continuity/PROMPT_CONTINUE_CLAUDE.md
@@ -1,113 +1,66 @@
-# PROMPT DE CONTINUIDAD — aRGus NDR — DAY 231
+# PROMPT DE CONTINUIDAD — aRGus NDR — DAY 234
 
-## Punto de entrada (léeme primero)
+## Punto de entrada (mide, no asumas)
+    git log --oneline -6 main
+    vagrant status          # el stack se paró al cerrar DAY 233 (make pipeline-stop)
+Tras DAY 233: día de MEDICIÓN, sin código nuevo. Commits solo docs
+(este prompt + BACKLOG). Artefactos del día bajo /vagrant/logs/ (ignorado):
+oros argus-A.parquet / suricata-A.parquet y la BD logs/day233-kuzu/mitre.kuzu.
 
-Al arrancar, **mide el estado, no lo asumas**:
-
-```
-git log --oneline -5 main
-git branch
-vagrant status
-```
-
-Estado esperado tras DAY 230: `fix/sniffer-ip-byte-order` (PR #127) y
-`feat/suricata-to-graph` (PR #128) **mergeadas a main**; una sola rama, el
-repo entrando en su tramo de cierre. Las ramas `feat/suricata-to-graph` y
-`feat-prerebase-backup` deberían estar borradas. Si `git log` no muestra los
-dos merges en main, esa es la primera tarea antes que ninguna otra.
-
-## El ⚪️ que ordena el día
-
-**DEBT-SNIFFER-IP-BYTE-ORDER-001 está ARREGLADA EN CÓDIGO
-(test_ip_format 6/6 + EMECAS+++ verde), pero el E2E CON DATOS REALES sigue
-PENDIENTE.** Nadie ha visto todavía un bronce nuevo con IPs `147.32.84.x`
-reales, ni la convergencia aRGus↔Suricata en el mismo `NetworkFlow`. EMECAS
-verde **no** cierra esto: su `test_bronze_to_kuzu_circuit` firma con clave
-constante y datos de fixture — es ciego al byte order. El cierre real llega
-provocando tráfico real al grafo (paso 2 del plan de cierre, script MITRE).
-**No marcar la deuda "cerrada" hasta medir eso.**
+## El estado que ordena el día
+**Paso 2 del cierre CERRADO (DAY 233).** MITRE → grafo por los dos sensores,
+con dato FRESCO (no el Neris de 2011):
+- nmap -sS NO disparó ET Open (52.058 reglas cargadas → cobertura ciega a un
+  SYN scan; PÁGINA DE PAPER). hydra descartado (ssh de defender key-only).
+  **nmap -A SÍ disparó** (ET SCAN Nmap User-Agent en 8080/Jenkins).
+- aRGus capturó (2a: 2.625 filas oro) + Suricata alertó (48 alert → oro).
+- Los dos oros a una Kuzu fresca (loader ×2, NO verifica HMAC → conviven la
+  clave real de aRGus y la de juguete de Suricata) → poblador CORRELATES_FLOW.
+- MEDIDO: **44 community_id corroborados cross-sensor**, **253 aristas** de
+  observación, invariante (cids distintos en extremos) = **0**, ambos sensores
+  TelemetryEvent (Reading A).
+- Números honestos para el paper: 44 flujos corroborados (titular); 253 =
+  pares de observación, NO 44... digo NO "253 flujos".
 
 ## Invariantes (no negociar)
+- Medir, no votar. HECHO ≠ SOSPECHADO; cada afirmación a salida de comando.
+- Join SIEMPRE por community_id, nunca por flow_uid.
+- Un día, una batalla. Via Appia (un criterio que no puede ponerse rojo no mide).
+- No `grep -rn` desde raíz (usa `git grep`). No encadenar salidas grandes.
+  `git add` explícito por fichero. A horas malas, parar.
 
-- **Medir, no votar.** Cada afirmación se traza a salida de comando. HECHO ≠
-  SOSPECHADO. Verde en un test sintético no es verde en el sistema.
-- **Un día, una batalla.** Elegir una y cerrarla; no abrir tres frentes.
-- **Via Appia.** Construir para durar; un criterio que no puede ponerse rojo
-  no mide nada.
-- No `grep -rn` desde la raíz (arrastra build/.git/.venv — un grep así corrió
-  toda una noche sin acabar); usar `git grep`. No encadenar comandos de salida
-  grande en el mismo bloque del terminal.
+## Candidatos de batalla DAY 234 (decide Alonso)
+- **A — Reproducibilidad (recomendado).** El resultado de DAY 233 se construyó
+  A MANO; el criterio de cierre exige que TODO dato sea generable por tareas del
+  Makefile. Convertir el recorrido de hoy (up → pipeline-start → clave del REST →
+  nmap -A → adapters → converters → loader ×2 → poblador → consultas) en un target
+  reproducible. Sin esto, el titular del paper no es "reproducible", es anecdótico.
+- **B — Paso 4: el paper.** Empezar a redactar con los números de hoy + el
+  hallazgo ET Open (52k reglas ciegas a -sS, sí a -A). Verificar citas
+  (Sommer & Paxson, Arp et al.) ANTES de usarlas.
+- **C — D4 / alcance.** Traer el 98,7% de Suricata (dns/http/tls) al grafo, o
+  el zeek-adapter, o imagen vulnerable (paso B, cadenas de ataque reales).
 
-## Qué se cerró en DAY 230
+## Deudas afloradas DAY 233 (registrar en docs/BACKLOG.md)
+- **DEBT-EVENT-ID-COLLISION-001** (NUEVA): argus 2.625 filas bronce → 1.522
+  TelemetryEvent. El event_id = timestamp_(src^dst) colisiona bajo carga de scan
+  (mismo segundo + mismo XOR). No toca la correlación (va por community_id), sí
+  la cardinalidad de eventos. Data-quality.
+- **window sin bucket** (ADR-052 §3.1.4 nunca implementado): window a microsegundo
+  → cada sensor registra una conversación como varios NetworkFlow → 37/44 cids
+  dan 253 aristas. Es la causa de la "inflación" de aristas. Ligada a
+  DEBT-FLOWSTART-CLOCK-DOMAIN-001 y a node_id por-sensor (§3.1.2), aún pendientes
+  de registrar reencuadradas desde DAY 232.
 
-1. **Hallazgo de paper, medido.** El crosscheck de paridad de `community_id`
-   disparó `exit 2` durante ~5 meses etiquetado como "cobertura asimétrica
-   esperada" (ruido). Medido en `logs/lab/cid-xcheck-anomalies.tsv` (42.838
-   líneas, mtime 2-jun, ~14k anomalías): las filas de aRGus llevaban IPs
-   invertidas (`165.84.32.147` = host Neris del CTU-13 swapeado) mientras
-   Suricata+Zeek acordaban las correctas (`147.32.84.165`). Dos puertas
-   cerradas: el bug llegó al oráculo (`community_id_log.cpp` comparte la
-   corrupción de IP) y el 3-way corrió de verdad. CAVEAT: el anomalies.tsv es
-   PRE-fix → prueba que el bug era real, NO verifica el arreglo. Es página de
-   paper.
-2. **DEBT-VM-SENSOR-NO-TOOLCHAIN-001 pagada y probada desde cero.** Bloque
-   `ADAPTER_TOOLCHAIN` en el Vagrantfile raíz (suricata/zeek/wazuh),
-   verificación por invocación (`g++ -fsyntax-only` sobre `#include`, no
-   `test -f`). Probado en EMECAS: `Setting up build-essential` en la VM
-   `suricata` recreada de cero.
-3. **emecas:1262** `vagrant up` → `vagrant up defender client suricata` (antes
-   levantaba solo `defender` por el `autostart:false` de los sensores, así que
-   el gate nunca ejercitaba la VM de sensor ni el toolchain).
-4. **#127** fix→main. **#128** feat rebasada sobre main (byte order heredado,
-   `ip_host_to_buffer` verificado en las 4 llamadas de `ring_consumer.cpp`) +
-   EMECAS+++ verde → main.
+## Notas de fontanería DAY 233 (medidas, no re-medir)
+- Clave HMAC del bronce de aRGus: la LEE el etcd-server, no Vault.
+  `curl -s http://localhost:2379/secrets/ml-detector` (campo `key`, 64 hex) con el
+  stack arriba. NO `etcdctl` (sirve HTTP plano en :2379, no KV). Efímera: no parar
+  el pipeline entre firmar bronce y convertir.
+- suricata-adapter: binario en `build-suricata/suricata_adapter` (guion bajo);
+  CLI posicional `<config.json>`, sin --help; alert-only (D4). Firma con
+  ARGUS_BRONZE_HMAC_KEY_HEX (juguete 0123456789abcdef×4 vale para Suricata).
+- Poblador y consultas cross-sensor: en [[mitre-ataque]] de la memoria.
 
-## Deudas abiertas relevantes
-
-- **DEBT-SNIFFER-IP-BYTE-ORDER-001** — ARREGLADA EN CÓDIGO, E2E CON DATOS
-  REALES PENDIENTE (paso 2 MITRE). *El ⚪️ del día.*
-- **DEBT-SENSOR-VMS-IN-ROOT-VAGRANTFILE-001** (DAY 230) — las 3 VMs de sensor
-  viven en el Vagrantfile raíz; separarlas exige resolver la red interna
-  compartida (`ml_defender_gateway_lan`) que el crosscheck necesita. Futuro,
-  NO cierre.
-- **DEBT-SURICATA-VM-DUPLICADA-001** (DAY 230) — dos VMs `suricata` (raíz vs
-  `experiments/suricata-comparative/`) con provisioning independiente. Medir
-  si la de experiments/ necesita el mismo toolchain y lo tiene.
-- **DEBT-BRONZE-KEY-PROVISIONING-001** — dos fuentes de verdad para la clave
-  HMAC: aRGus firma con clave de etcd (runtime), el consumidor del
-  correlation-engine lee de env. Con bronce plano + consumidor de clave única,
-  hay que unificar. Sin resolver.
-- **Telemetría D4** — los ~104k eventos dns/http/tls de Suricata (98,7% del
-  volumen) siguen descartados; no llegan al grafo. Alonso ratificó DAY 230 que
-  "que toda la información de Suricata acabe en el grafo" es la misión.
-
-## Batalla candidata para DAY 231
-
-**Recomendación: paso 2 del plan de cierre — script MITRE → tráfico real →
-grafo.** Cierra tres cosas de una: (a) el ⚪️ del byte order (bronce con IPs
-reales + convergencia aRGus↔Suricata en el mismo `NetworkFlow`); (b) es el
-siguiente paso natural del cierre; (c) hace observable el movimiento lateral
-(Wazuh, arista Host↔Flow inferencial) que un replay de pcap no produce.
-
-Primer paso barato: localizar el mecanismo de generación de tráfico real
-—¿existe ya?— con `git grep -il mitre`, `ls experiments/`, y mirar el
-`client-setup` (clona atomic-red-team).
-
-Alternativas, si se prefiere otro frente:
-
-- **Telemetría D4 al grafo** (la misión "toda la info"). Muro a medir ANTES de
-  mapear: `validate()` exige `community_id` como requisito duro de
-  correlation_v1 y los dns/http/tls pueden no llevarlo → decidir Opción A
-  (aceptar `TelemetryEvent` sin cid) o sintetizar. Medida barata:
-  `tools/eval/eve_field_coverage.py` (cobertura de community_id por tipo de
-  evento).
-- **is_external_ip / is_new_external_ip** (`fast_detector.cpp`). ¿El fast path
-  sigue clasificando interno como externo? Usa `evt.dst_ip` numérico, el fix
-  de ayer no lo tocó. Lectura barata, correctness viva; si está roto, abre otra
-  batalla.
-
-## Recordatorio de tono de trabajo
-
-Alonso pilota; mide contra fichero y pégalo, no votes de memoria. Fichero
-completo, no `sed -n`. `git add` explícito por fichero (nunca `-A`/`-u`: se
-cuela scratch). A las horas malas, parar antes que forzar un merge o un rebase.
+## Recordatorio de tono
+Alonso pilota; mide contra fichero y pega salida. `make pipeline-stop` al cerrar.

--- a/scripts/mitre_start.sh
+++ b/scripts/mitre_start.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# scripts/mitre_start.sh — DAY 234. Automatiza el camino MITRE -> grafo de DAY 233.
+# `make mitre-start` deja aristas cross-sensor (aRGus<->Suricata) en Kuzu con datos
+# DEL DIA, cero comandos manuales. Requiere `make pipeline-start` antes.
+# Se ejecuta en el HOST; trabaja en los guests via vagrant ssh. A. Roman + Claude.
+set -uo pipefail
+# NOT A SECRET — clave de juguete de test, DAY 227. La clave real se saca en runtime por curl.
+TOY_KEY="0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"# gitleaks:allow # pragma: allowlist secret
+CE="/vagrant/correlation-engine/build"; SCHEMA="/vagrant/correlation-engine/schema/schema.cypher"
+LAB="/vagrant/logs/lab"; ADAPTER="/vagrant/suricata-adapter/build-suricata/suricata_adapter"
+STAMP="$(date -u +%Y%m%d-%H%M%S)"; KUZU="/vagrant/logs/day234-kuzu/mitre-$STAMP.kuzu"
+die(){ echo "X $*" >&2; exit 1; }
+
+echo ""
+echo "##################################################################"
+echo "#  ALERT  ##  HACK DE DESARROLLO — NO APTO PARA PRODUCCION  ##    #"
+echo "#                                                                #"
+echo "#  mitre-start saca la clave HMAC con un GET HTTP EN CLARO al     #"
+echo "#  etcd-server (curl http://localhost:2379/secrets/ml-detector).  #"
+echo "#  Clave de cifrado en TEXTO PLANO por la red, sin TLS ni auth.   #"
+echo "#  DEBT-HMAC-KEY-INSECURE-TRANSPORT-001 (P1) +                    #"
+echo "#  DEBT-BRONZE-KEY-PROVISIONING-001. Arreglo correcto (NO aqui):  #"
+echo "#  converter y componentes DIRECTOS a Vault (auth/TLS/leases);    #"
+echo "#  idealmente Jenkins exporta esta env var al crear la clave.     #"
+echo "#  Quien mantenga el pipeline: hazlo a tu manera, pero hazlo.     #"
+echo "##################################################################"
+echo ""
+
+# 1) Clave HMAC del bronce (el hack)
+KEY=$(vagrant ssh defender -c "curl -s http://localhost:2379/secrets/ml-detector | python3 -c 'import sys,json; print(json.load(sys.stdin)[\"key\"])'" 2>/dev/null | tr -d '\r')
+[ ${#KEY} -eq 64 ] || die "clave HMAC no es 64 hex (len=${#KEY}). ¿pipeline-start arriba? ¿etcd-server RUNNING?"
+echo "OK clave HMAC en mano (64 hex, head ${KEY:0:8}...)"
+
+# 2) Marca T0 y disparo MITRE (nmap -A: el que hace reaccionar a los DOS sensores)
+vagrant ssh defender -c "touch $LAB/mitre-t0-$STAMP.marker"
+echo "-- Disparo MITRE (nmap -A) desde client contra defender --"
+vagrant ssh client -c "sudo nmap -A 192.168.100.1" || die "nmap fallo"
+echo "-- Drenaje 45s --"; sleep 45
+
+# 3) Oro de aRGus: bronce de la ventana del ataque (mtime > T0), convertido con la clave real
+vagrant ssh defender -c "cat \$(find /vagrant/logs/correlation -name 'argus-*.csv' -newer $LAB/mitre-t0-$STAMP.marker | sort) > $LAB/argus-$STAMP.bronce.csv"
+vagrant ssh defender -c "cd $CE && ARGUS_BRONZE_HMAC_KEY_HEX=$KEY ./bronze_to_gold_converter $LAB/argus-$STAMP.bronce.csv $LAB/argus-$STAMP.avro $LAB/argus-$STAMP.parquet" | tee /tmp/argus-conv.log
+grep -q "descartadas: 0" /tmp/argus-conv.log || die "aRGus: descartadas>0 -> la clave no caso (¿pipeline reiniciado? ¿rotacion?)"
+
+# 4) Oro de Suricata: adapter alert-only sobre el eve.json vivo (clave de juguete, el loader no verifica HMAC)
+vagrant ssh suricata -c "sudo cp /var/log/suricata/eve.json $LAB/eve-$STAMP.json && sudo chmod 644 $LAB/eve-$STAMP.json"
+vagrant ssh suricata -c "python3 -c \"import json; json.dump({'base_dir':'$LAB','node_id':'cpp_sniffer_v33_day12','input_path':'logs/lab/eve-$STAMP.json','hmac_key_env':'ARGUS_BRONZE_HMAC_KEY_HEX'}, open('$LAB/suri-adapter-$STAMP.json','w'))\""
+vagrant ssh suricata -c "cd /vagrant && ARGUS_BRONZE_HMAC_KEY_HEX=$TOY_KEY $ADAPTER $LAB/suri-adapter-$STAMP.json"
+SURI_CSV=$(vagrant ssh suricata -c "ls -t $LAB/suricata-*.csv | head -1" 2>/dev/null | tr -d '\r')
+vagrant ssh defender -c "cd $CE && ARGUS_BRONZE_HMAC_KEY_HEX=$TOY_KEY ./bronze_to_gold_converter $SURI_CSV $LAB/suricata-$STAMP.avro $LAB/suricata-$STAMP.parquet"
+
+# 5) Kuzu fresca + carga de los dos oros + poblador CORRELATES_FLOW
+vagrant ssh defender -c "mkdir -p /vagrant/logs/day234-kuzu"
+vagrant ssh defender -c "cd $CE && ./parquet_to_kuzu_loader $LAB/argus-$STAMP.parquet $KUZU $SCHEMA"
+vagrant ssh defender -c "cd $CE && ./parquet_to_kuzu_loader $LAB/suricata-$STAMP.parquet $KUZU $SCHEMA"
+vagrant ssh defender -c "cd $CE && ./kuzu_query $KUZU \"MATCH (a:NetworkFlow),(b:NetworkFlow) WHERE a.community_id=b.community_id AND a.flow_uid<b.flow_uid MERGE (a)-[e:CORRELATES_FLOW]->(b) ON CREATE SET e.community_id=a.community_id, e.method='community_id', e.confidence=1.0\""
+
+# 6) Veredicto del dia
+echo ""; echo "======== MITRE -> GRAFO ($STAMP) ========"
+echo "-- sensores en el grafo --"
+vagrant ssh defender -c "cd $CE && ./kuzu_query $KUZU \"MATCH (e:TelemetryEvent) RETURN e.source_sensor, count(*)\""
+echo "-- invariante (debe ser 0) --"
+vagrant ssh defender -c "cd $CE && ./kuzu_query $KUZU \"MATCH (a:NetworkFlow)-[e:CORRELATES_FLOW]->(b:NetworkFlow) WHERE a.community_id<>b.community_id RETURN count(*)\""
+echo "-- flujos corroborados cross-sensor (EL TITULAR) --"
+vagrant ssh defender -c "cd $CE && ./kuzu_query $KUZU \"MATCH (ea:TelemetryEvent)-[:TELEMETRY_ABOUT]->(a:NetworkFlow)-[e:CORRELATES_FLOW]-(b:NetworkFlow)<-[:TELEMETRY_ABOUT]-(eb:TelemetryEvent) WHERE ea.source_sensor<>eb.source_sensor RETURN count(DISTINCT e.community_id)\""
+echo "BD: $KUZU"; echo "========================================="


### PR DESCRIPTION
44 flujos corroborados cross-sensor (aRGus<->Suricata), 253 aristas, invariante 0. Anade scripts/mitre_start.sh (esqueleto DAY 234, sin probar) y 4 deudas al BACKLOG: EVENT-ID-COLLISION, FLOWUID-WINDOW-BUCKET, DOWNSTREAM-TO-GRAPH-NOT-AUTOMATED, HMAC-KEY-INSECURE-TRANSPORT.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated end-to-end workflow for generating and validating MITRE-to-graph correlations across network sensors.
  * Added verification checks and reporting for cross-sensor flow relationships.

* **Documentation**
  * Updated continuity guidance and operational status for the latest pipeline work.
  * Documented outstanding issues involving event identity collisions, flow-window accuracy, reproducibility, and secure secret handling.
  * Added proposed steps to make the complete telemetry-to-graph process fully reproducible without manual commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->