### PR TITLE
Day234/mitre start automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3069,3 +3069,7 @@ suricata-adapter-test: suricata-adapter-build
 suricata-adapter-clean:
 	@vagrant ssh suricata -c "rm -rf $(SURICATA_ADAPTER_BUILD_DIR)"
 	@echo "✅ suricata-adapter cleaned"
+
+.PHONY: mitre-start
+mitre-start: ## MITRE -> grafo (requiere pipeline-start arriba). Ver DEBT-HMAC-KEY-INSECURE-TRANSPORT-001.
+	@bash scripts/mitre_start.sh

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -5558,3 +5558,26 @@ Suricata: provisioning que no verifica el resultado real.
   token/AppRole, TLS, leases, secretos dinámicos), eliminando el REST plano
   intermedio. Es una de las PRIMERAS cosas a afrontar por quien mantenga el
   pipeline, junto con la creación de los modelos del ml-detector y el fast-path.
+
+## 🆕 Entradas DAY 234 — mitre-start reproducible: hallazgos de la primera corrida E2E
+
+### DEBT-MITRE-SURICATA-EVE-NOT-WINDOWED-001 — el adapter de Suricata en mitre-start lee el eve.json entero, no la ventana del ataque
+**Severidad:** 🟢 P3 — polución de censo en stack caliente; NO corrompe el titular; neutralizada por el baseline destroy→up
+**Estado:** ABIERTO — DAY 234 (medido: 2 corridas dejaron 113 alertas donde un ataque da ~48–65)
+**Componente:** `scripts/mitre_start.sh` (paso del suricata-adapter) + `suricata-adapter` (lee la entrada completa)
+
+La mitad aRGus se recorta por `mtime>T0` (solo el ataque de este run), pero el adapter de Suricata relee el `eve.json` acumulado → en stack caliente arrastra las alertas de runs anteriores (la corrida que murió en la línea 48 dejó su `nmap -A` en el eve.json sin consumir). Medido DAY 234: suricata=113 eventos en el grafo vs ~48 de un solo ataque; la tasa de corroboración baja (14/103) por denominador contaminado, aunque el titular (14 flujos, DISTINCT community_id cross-sensor) es correcto. Bajo `destroy -f && up` el eve.json nace vacío y desaparece. Fix opcional de hardening: windowear la lectura del adapter a T0, simétrico con argus. Decidir al promover mitre-start a tarea EMECAS+++.
+
+### DEBT-EVENT-ID-COLLISION-001 — el event_id de aRGus colisiona bajo carga de scan y puede tragarse una corroboración del grafo
+**Severidad:** 🟡 P2 — data-quality; en el peor caso reduce el titular cross-sensor sin avisar
+**Estado:** ABIERTO — DAY 234 (medido DAY 233 y 234)
+**Componente:** `ml-detector` (acuñación del event_id del bronce de aRGus) → PK de `TelemetryEvent`
+
+El esquema `timestamp_(src^dst)` colisiona bajo scan: muchas filas del mismo segundo con el mismo XOR de IPs comparten event_id. Medido: DAY 233 argus 2625 bronce → 1522 TelemetryEvent; DAY 234 2414 → 1326. No afecta la CORRELACIÓN (va por community_id), pero el MERGE por PK conserva una sola fila; si dos colisionantes traen community_id distintos, **puede borrar del grafo un cid que sí está en el bronce**. Relación honesta: `titular_grafo ≤ intersección_grep`, nunca al revés. DAY 234 salió `14 == 14` (ninguna perdida en este run), no garantizado. Cuando el gate auto-verify de mitre-start vea `grafo < grep`, NO es bug de consulta: es esta colisión → WARN + log (dato de paper), no abort.
+
+### DEBT-DATASETS-FETCH-NOT-AUTOMATED-001 — la reproducibilidad de los targets de eval exige descarga manual de datasets
+**Severidad:** 🟡 P2 — rompe "reproducibilidad = propiedad del repo" para la ruta de eval ML del paper
+**Estado:** ABIERTO — DAY 234
+**Componente:** (sin target) — futuro `make fetch-datasets`
+
+El baseline reproducible es `destroy -f && up` desde cero. `mitre-start` NO necesita datasets (genera su tráfico con `nmap -A` en vivo), pero los targets que respaldan los números de ML del paper (transferencia CICIDS2017→Neris 0.0001, PROBE 0, comparación de 3 paradigmas) consumen CTU-13 Neris y CICIDS2017, hoy en `/vagrant/datasets/` a mano. Para que "reproducible = un comando" cubra la ruta de eval hace falta `fetch-datasets` (descarga desde las URLs canónicas de Stratosphere IPS / UNB + verificación de checksum). Separado de mitre-start; solo la ruta de eval depende de él.

--- a/docs/continuity/PROMPT_CONTINUE_CLAUDE.md
+++ b/docs/continuity/PROMPT_CONTINUE_CLAUDE.md
@@ -1,66 +1,72 @@
-# PROMPT DE CONTINUIDAD — aRGus NDR — DAY 234
+# PROMPT DE CONTINUIDAD — aRGus NDR — DAY 235
 
 ## Punto de entrada (mide, no asumas)
     git log --oneline -6 main
-    vagrant status          # el stack se paró al cerrar DAY 233 (make pipeline-stop)
-Tras DAY 233: día de MEDICIÓN, sin código nuevo. Commits solo docs
-(este prompt + BACKLOG). Artefactos del día bajo /vagrant/logs/ (ignorado):
-oros argus-A.parquet / suricata-A.parquet y la BD logs/day233-kuzu/mitre.kuzu.
+    vagrant status
+Tras DAY 234: `mitre-start` corre E2E (fix de UN espacio en la línea 8 del script).
+Titular reproducible = 14, VALIDADO (grafo == grep, dos métodos sin código común).
+Commits del día: fix del script + entradas de BACKLOG (docs). Artefactos bajo
+/vagrant/logs/day234-kuzu/ y /vagrant/logs/lab/ (ignorados).
 
 ## El estado que ordena el día
-**Paso 2 del cierre CERRADO (DAY 233).** MITRE → grafo por los dos sensores,
-con dato FRESCO (no el Neris de 2011):
-- nmap -sS NO disparó ET Open (52.058 reglas cargadas → cobertura ciega a un
-  SYN scan; PÁGINA DE PAPER). hydra descartado (ssh de defender key-only).
-  **nmap -A SÍ disparó** (ET SCAN Nmap User-Agent en 8080/Jenkins).
-- aRGus capturó (2a: 2.625 filas oro) + Suricata alertó (48 alert → oro).
-- Los dos oros a una Kuzu fresca (loader ×2, NO verifica HMAC → conviven la
-  clave real de aRGus y la de juguete de Suricata) → poblador CORRELATES_FLOW.
-- MEDIDO: **44 community_id corroborados cross-sensor**, **253 aristas** de
-  observación, invariante (cids distintos en extremos) = **0**, ambos sensores
-  TelemetryEvent (Reading A).
-- Números honestos para el paper: 44 flujos corroborados (titular); 253 =
-  pares de observación, NO 44... digo NO "253 flujos".
+**Batalla A (mitre-start reproducible) mecánicamente GANADA, CONGELADA hasta que
+entren Zeek+Wazuh.** Va de stack-arriba a aristas cross-sensor sin comandos
+manuales; titular 14 honesto. Su promoción a TAREA EMECAS+++ (test de aceptación
+destroy→up desde cero + gate auto-verify grafo-vs-grep) se hará CUANDO el script
+esté completo con los cuatro sensores, no antes.
+**Siguiente: Zeek al grafo.** Paso 2 del roadmap post-233.
 
 ## Invariantes (no negociar)
 - Medir, no votar. HECHO ≠ SOSPECHADO; cada afirmación a salida de comando.
-- Join SIEMPRE por community_id, nunca por flow_uid.
+- Identidad de flujo = hash(node_id ‖ community_id), SIN tiempo (Opción B, DAY 225).
+  node_id = punto de observación, NO el host. Join SIEMPRE por community_id.
 - Un día, una batalla. Via Appia (un criterio que no puede ponerse rojo no mide).
 - No `grep -rn` desde raíz (usa `git grep`). No encadenar salidas grandes.
-  `git add` explícito por fichero. A horas malas, parar.
+  `git add` explícito por fichero. macOS: nunca `sed -i` sin `-e ''` (Python3 heredoc).
+  A horas malas, parar.
 
-## Candidatos de batalla DAY 234 (decide Alonso)
-- **A — Reproducibilidad (recomendado).** El resultado de DAY 233 se construyó
-  A MANO; el criterio de cierre exige que TODO dato sea generable por tareas del
-  Makefile. Convertir el recorrido de hoy (up → pipeline-start → clave del REST →
-  nmap -A → adapters → converters → loader ×2 → poblador → consultas) en un target
-  reproducible. Sin esto, el titular del paper no es "reproducible", es anecdótico.
-- **B — Paso 4: el paper.** Empezar a redactar con los números de hoy + el
-  hallazgo ET Open (52k reglas ciegas a -sS, sí a -A). Verificar citas
-  (Sommer & Paxson, Arp et al.) ANTES de usarlas.
-- **C — D4 / alcance.** Traer el 98,7% de Suricata (dns/http/tls) al grafo, o
-  el zeek-adapter, o imagen vulnerable (paso B, cadenas de ataque reales).
+## Candidato de batalla DAY 235 — Zeek al grafo (Alonso decide el corte)
+Adapter de Zeek: estándar de [[suricata-adapter]] + alcance N-ficheros (DAY 227,
+"todo el jugo"). Corte MVP recomendado (espejo de Suricata DAY 226): SOLO conn.log.
+1. `vagrant up zeek` (hoy not created) → EJERCITA POR PRIMERA VEZ el camino
+   from-scratch del bloque ADAPTER_TOOLCHAIN (DAY 230). Ver los 6 paquetes
+   INSTALARSE, no "ya presentes". Paga DEBT-VM-SENSOR-NO-TOOLCHAIN-001 de verdad.
+2. Verificar community_id en conn.log CONTRA FICHERO, con la lección DAY 225:
+   comparar mtime de site/local.zeek vs hora de arranque del proceso Zeek (la config
+   correcta que el proceso vivo no ha leído). Diana seed 0: 1:IN7uqVpMWxpmuhQTowSQB2XEe0E=
+3. Cobertura de campos de conn.log (tools/eval/eve_field_coverage.py o equivalente).
+4. `scaffold_adapter.py --sensor zeek` → stub to_row.cpp que falla ruidoso →
+   escribir el mapeo conn.log → 19 cols. Zeek es TELEMETRÍA (F1 0.042) →
+   TelemetryEvent, cols de veredicto vacías (D6). flow_start de conn.log = ts (D4).
+5. Criterio del día: N filas de Zeek en el bronce, TODAS pasando validate().
+   NI oro NI Kuzu (eso es el día siguiente, como en la progresión de Suricata).
+   Alternativas: ampliar a N ficheros (dns/http/ssl) = "todo el jugo", batalla posterior;
+   o el paso 4 (paper).
 
-## Deudas afloradas DAY 233 (registrar en docs/BACKLOG.md)
-- **DEBT-EVENT-ID-COLLISION-001** (NUEVA): argus 2.625 filas bronce → 1.522
-  TelemetryEvent. El event_id = timestamp_(src^dst) colisiona bajo carga de scan
-  (mismo segundo + mismo XOR). No toca la correlación (va por community_id), sí
-  la cardinalidad de eventos. Data-quality.
-- **window sin bucket** (ADR-052 §3.1.4 nunca implementado): window a microsegundo
-  → cada sensor registra una conversación como varios NetworkFlow → 37/44 cids
-  dan 253 aristas. Es la causa de la "inflación" de aristas. Ligada a
-  DEBT-FLOWSTART-CLOCK-DOMAIN-001 y a node_id por-sensor (§3.1.2), aún pendientes
-  de registrar reencuadradas desde DAY 232.
+## Deudas registradas DAY 234 (en docs/BACKLOG.md, sección 🆕 Entradas DAY 234)
+- DEBT-MITRE-SURICATA-EVE-NOT-WINDOWED-001 (P3): adapter Suricata lee el eve.json
+  entero → arrastre en caliente; neutralizado por destroy→up.
+- DEBT-EVENT-ID-COLLISION-001 (P2): event_id colisiona bajo scan; puede tragarse
+  una corroboración (titular_grafo ≤ intersección_grep).
+- DEBT-DATASETS-FETCH-NOT-AUTOMATED-001 (P2): fetch de CTU-13/CICIDS para la ruta
+  de eval del paper (mitre-start NO lo necesita).
 
-## Notas de fontanería DAY 233 (medidas, no re-medir)
-- Clave HMAC del bronce de aRGus: la LEE el etcd-server, no Vault.
-  `curl -s http://localhost:2379/secrets/ml-detector` (campo `key`, 64 hex) con el
-  stack arriba. NO `etcdctl` (sirve HTTP plano en :2379, no KV). Efímera: no parar
-  el pipeline entre firmar bronce y convertir.
-- suricata-adapter: binario en `build-suricata/suricata_adapter` (guion bajo);
-  CLI posicional `<config.json>`, sin --help; alert-only (D4). Firma con
-  ARGUS_BRONZE_HMAC_KEY_HEX (juguete 0123456789abcdef×4 vale para Suricata).
-- Poblador y consultas cross-sensor: en [[mitre-ataque]] de la memoria.
+## A medir (afecta al paper, no bloquea)
+¿Está la Opción B (flow_uid sin tiempo, DAY 225) IMPLEMENTADA en código, o solo
+decidida? Si sí, reencuadrar por qué DAY 233 dio 253 aristas de observación (el
+self-join por community_id sobre múltiples TelemetryEvent por cid, no el window).
+Si no, el window-sin-bucket sigue vivo. Medir antes de escribir la sección del grafo.
+
+## Notas de fontanería DAY 234 (medidas, no re-medir)
+- Fix del TOY_KEY: un espacio antes del `#` en la anotación gitleaks:allow (línea 8).
+  Sin espacio, `VAR="..."# cmd` es asignación-prefijo → bash corre `cmd` y VAR no persiste.
+- mitre-start crea Kuzu FRESCA por run: /vagrant/logs/day234-kuzu/mitre-<STAMP>.kuzu.
+- La clave HMAC real sigue saliendo por curl HTTP en claro a :2379 (DEBT-HMAC-KEY-
+  INSECURE-TRANSPORT-001, P1) — envuelta en el ALERT del script; NO es producción.
+- community_id = col 5 del bronce (CSV). Método fiable de intersección: `grep -Fxf`
+  con LC_ALL=C (inmune a locale), NO `comm` (dio números basura en DAY 233).
+- ADAPTER_TOOLCHAIN ya está en el Vagrantfile para zeek+wazuh (DAY 230), pero el
+  camino from-scratch (instalando) NUNCA se ha probado.
 
 ## Recordatorio de tono
 Alonso pilota; mide contra fichero y pega salida. `make pipeline-stop` al cerrar.

--- a/scripts/mitre_start.sh
+++ b/scripts/mitre_start.sh
@@ -5,7 +5,7 @@
 # Se ejecuta en el HOST; trabaja en los guests via vagrant ssh. A. Roman + Claude.
 set -uo pipefail
 # NOT A SECRET — clave de juguete de test, DAY 227. La clave real se saca en runtime por curl.
-TOY_KEY="0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"# gitleaks:allow # pragma: allowlist secret
+TOY_KEY="0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" # gitleaks:allow # pragma: allowlist secret
 CE="/vagrant/correlation-engine/build"; SCHEMA="/vagrant/correlation-engine/schema/schema.cypher"
 LAB="/vagrant/logs/lab"; ADAPTER="/vagrant/suricata-adapter/build-suricata/suricata_adapter"
 STAMP="$(date -u +%Y%m%d-%H%M%S)"; KUZU="/vagrant/logs/day234-kuzu/mitre-$STAMP.kuzu"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `mitre-start` command to launch the MITRE graph workflow.

* **Documentation**
  * Documented reproducible end-to-end workflow findings and updated the project roadmap.
  * Added tracking for alert-windowing, event-correlation, and dataset setup considerations.
  * Updated continuity notes with the next Zeek-to-graph integration steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->