### PR TITLE
chore: preservar scripts de scaffolding/verificacion (scratch DAY 240…

### DIFF
--- a/build-hostfile.sh
+++ b/build-hostfile.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Ejecutar desde la raíz del repo (test-zeromq-docker).
+test -f Vagrantfile || { echo "ERROR: ejecuta esto desde la raíz del repo"; exit 1; }
+
+mkdir -p host-engine/tools
+[ -f host-engine/CMakeLists.txt ] || : > host-engine/CMakeLists.txt
+[ -f host-engine/tools/host_bronze_to_gold_converter.cpp ] || : > host-engine/tools/host_bronze_to_gold_converter.cpp
+
+echo "Estructura host-engine/:"
+find host-engine -type f | sort

--- a/create_wazuh_adapter_skeleton.py
+++ b/create_wazuh_adapter_skeleton.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+create_wazuh_adapter_skeleton.py — aRGus NDR (DAY 242)
+
+Crea, desde la raíz del proyecto, la estructura del componente `wazuh-adapter/`
+(Pieza 1 del cierre host) con los 13 ficheros VACÍOS, listos para pegar el
+contenido entregado.
+
+SEGURO por diseño: nunca sobrescribe un fichero que YA existe (aunque esté
+vacío) — re-ejecutarlo no destruye trabajo ya pegado; solo crea lo que falta.
+
+NO toca nada fuera de `wazuh-adapter/`: ni el Makefile raíz (edición a mano),
+ni `libs/host-domain-v1/` (existe de la Pieza 0), ni el CMakeLists raíz.
+
+Uso:
+    python3 create_wazuh_adapter_skeleton.py            # crea en el cwd
+    python3 create_wazuh_adapter_skeleton.py --root .   # idem, explícito
+    python3 create_wazuh_adapter_skeleton.py --dry-run  # enseña, no toca disco
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Los 13 ficheros del componente, relativos a la raíz del proyecto.
+FILES = [
+    "wazuh-adapter/.gitignore",
+    "wazuh-adapter/CMakeLists.txt",
+    "wazuh-adapter/README.md",
+    "wazuh-adapter/config/wazuh_adapter.json",
+    "wazuh-adapter/include/wazuh_adapter/batch_writer.hpp",
+    "wazuh-adapter/include/wazuh_adapter/config.hpp",
+    "wazuh-adapter/include/wazuh_adapter/to_row.hpp",
+    "wazuh-adapter/src/batch_writer.cpp",
+    "wazuh-adapter/src/config.cpp",
+    "wazuh-adapter/src/main.cpp",
+    "wazuh-adapter/src/to_row.cpp",
+    "wazuh-adapter/tests/CMakeLists.txt",
+    "wazuh-adapter/tests/test_to_row.cpp",
+]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Crea el esqueleto VACÍO de wazuh-adapter/ (Pieza 1, DAY 242)."
+    )
+    ap.add_argument("--root", default=".",
+                    help="Raíz del proyecto donde crear wazuh-adapter/ (por defecto: cwd).")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Enseña lo que haría, sin tocar el disco.")
+    args = ap.parse_args()
+
+    root = Path(args.root).resolve()
+    if not root.is_dir():
+        print(f"ERROR: la raíz no existe o no es un directorio: {root}", file=sys.stderr)
+        return 2
+
+    created, skipped = 0, 0
+    for rel in FILES:
+        path = root / rel
+        if path.exists():
+            print(f"  skip   (ya existe)  {rel}")
+            skipped += 1
+            continue
+        if args.dry_run:
+            print(f"  CREARÍA             {rel}")
+            continue
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()  # fichero VACÍO
+        print(f"  creado              {rel}")
+        created += 1
+
+    print()
+    if args.dry_run:
+        print("(dry-run: no se tocó el disco)")
+    else:
+        print(f"Hecho: {created} creados, {skipped} ya existían.  Raíz: {root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/verify_host_gold.py
+++ b/verify_host_gold.py
@@ -1,0 +1,15 @@
+import sys, pyarrow.parquet as pq
+t = pq.read_table(sys.argv[1])
+print("rows", t.num_rows, "| cols", t.num_columns)
+assert t.num_columns == 34, "no son 34 columnas"
+assert str(t.schema.field("rule_level").type) == "int32", "rule_level no es int32"
+assert str(t.schema.field("hmac_row").type) == "string", "falta hmac_row"
+d = t.to_pydict()
+found = 0
+for i, rid in enumerate(d["rule_id"]):
+    if rid == "5403":                       # sudo -> root (la espina privesc)
+        found += 1
+        assert d["rule_level"][i] == 4, f"rule_level != 4 en fila {i}"
+        assert "T1548.003" in d["mitre_ids"][i], f"T1548.003 ausente en fila {i}"
+print("filas rule_id=5403 verificadas:", found)
+print("OK" if (t.num_rows == 533 and found > 0) else "REVISAR")


### PR DESCRIPTION
…-245)

build-hostfile.sh, create_wazuh_adapter_skeleton.py, verify_host_gold.py: utilidades de apoyo del circuito host, se trackean para no perderlas. Posteriores al hito pre-release-0.0.1.